### PR TITLE
Fix workflow: Use temporary directory for CLIProxyAPI extraction

### DIFF
--- a/.github/workflows/update-cliproxyapi.yml
+++ b/.github/workflows/update-cliproxyapi.yml
@@ -20,6 +20,32 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Close old unmerged bump PRs
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_UPDATE_TOKEN }}
+        run: |
+          set -e
+          echo "Checking for existing auto-generated bump PRs..."
+          
+          OLD_PRS=$(gh pr list --state open --json number,headRefName,title --jq '.[] | select(.headRefName | startswith("bump-cliproxyapi-")) | "\(.number)|\(.title)"' || true)
+          
+          if [ -z "$OLD_PRS" ]; then
+            echo "No existing auto-generated bump PRs found."
+          else
+            echo "Found existing auto-generated bump PRs to close:"
+            
+            while IFS='|' read -r PR_NUMBER PR_TITLE; do
+              if [ -n "$PR_NUMBER" ]; then
+                echo "Closing PR #$PR_NUMBER: $PR_TITLE"
+                gh pr close "$PR_NUMBER" --comment "Closing this PR as a newer version bump is being created." || {
+                  echo "Warning: Failed to close PR #$PR_NUMBER" >&2
+                }
+              fi
+            done <<< "$OLD_PRS"
+            
+            echo "✓ Closed old auto-generated bump PRs"
+          fi
+
       - name: Get latest CLIProxyAPI release
         id: get-latest-release
         run: |


### PR DESCRIPTION
## Problem

The current workflow extracts the CLIProxyAPI tarball directly into the repository root, which causes unwanted files (LICENSE, README.md, README_CN.md, config files) to be committed to the repository. This was seen in PR #46 where the project's own LICENSE and README.md files were accidentally deleted.

## Solution

This PR updates the workflow to use a temporary directory for all extraction operations:

- Creates a secure temporary directory using `mktemp -d`
- Downloads and extracts the tarball entirely within the temp directory  
- Copies only the binary file to the target location
- Cleans up the entire temp directory after extraction
- Adds validation to ensure only the `cli-proxy-api` binary is modified in git

## Benefits

- ✅ No unwanted files extracted into the repository
- ✅ Project's LICENSE and README.md remain untouched
- ✅ Cleaner git commits with only the binary updated
- ✅ Better error handling with temp directory cleanup on failures
- ✅ Final validation to catch any unexpected file modifications

Fixes the issue seen in PR #46.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automation reliability with persistent temporary storage for downloads and extraction, stronger validation and error reporting, and safer file replacement behavior.
  * Added comprehensive cleanup on success or failure and post-run integrity checks to ensure only the intended artifact is changed.
  * Minor workflow stability and maintenance improvements for automated update runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->