### PR TITLE
Fix Codex login timeout when Google account selection is required

### DIFF
--- a/src/Sources/ServerManager.swift
+++ b/src/Sources/ServerManager.swift
@@ -280,6 +280,19 @@ class ServerManager: ObservableObject {
                 }
             }
         }
+
+        // For Codex login, avoid blocking on the manual callback prompt after ~15s.
+        if case .codexLogin = command {
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 12.0) {
+                // Send newline before the prompt to keep waiting for browser callback.
+                if authProcess.isRunning {
+                    if let data = "\n".data(using: .utf8) {
+                        try? inputPipe.fileHandleForWriting.write(contentsOf: data)
+                        NSLog("[Auth] Sent newline to keep Codex login waiting for callback")
+                    }
+                }
+            }
+        }
         
         // For Qwen login, automatically send email after OAuth completes
         // NOTE: 10 second delay chosen to ensure OAuth browser flow completes before submitting email.


### PR DESCRIPTION
## Summary

Fixes #111

A fix for the issue where Codex login would hang if the authentication flow takes longer than 15 seconds.

## Problem

CLIProxyAPI's Codex login prompts "Paste callback URL" after 15 seconds of waiting. Since VibeProxy doesn't have stdin interaction, any login flow that takes longer (e.g., when users need to select a Google account first) would cause the process to hang indefinitely.

## Solution

Added a scheduled newline input at 12 seconds for `.codexLogin` in `ServerManager.swift`, ensuring the process continues waiting for the browser callback rather than blocking on the manual input prompt.

This allows the Google account selection/login flow to complete successfully and write the auth file.

## Changes

- `src/Sources/ServerManager.swift`: Added 12-second delayed newline for Codex login flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Codex authentication to prevent blocking during browser-based login by implementing automatic timeout handling that proactively manages the authentication process, ensuring users are not stuck waiting on callback prompts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->