### PR TITLE
feat(config): add request-timeout configuration

### DIFF
--- a/src/Sources/Resources/config.yaml
+++ b/src/Sources/Resources/config.yaml
@@ -29,6 +29,11 @@ proxy-url: ""
 # Retry configuration
 request-retry: 3
 
+# Timeout for upstream provider requests
+# Default: 10m. Set to "0" to disable timeout.
+# Important for Extended Thinking requests which may take 5-10+ minutes.
+request-timeout: "10m"
+
 # Quota management
 quota-exceeded:
   switch-project: true


### PR DESCRIPTION
This PR adds explicit configuration for `request-timeout` to `config.yaml`.

### Summary
Adds `request-timeout: "10m"` to the default configuration.

### Dependency Note
This feature relies on the upstream **[CLIProxyAPIPlus PR #85](https://github.com/router-for-me/CLIProxyAPIPlus/pull/85)** (or a future release containing it). 
*   **Current State:** The current bundled binary will simply ignore this new configuration key, so it is safe to merge now.
*   **Future State:** Once the binary is updated, this configuration will explicitly control the timeout, preventing early failures on long-running requests (like Extended Thinking).

### Reasoning
While the updated binary defaults to 10 minutes internally if no config is present, adding this key provides:
1.  **Documentation:** Makes users aware that the timeout is configurable.
2.  **Flexibility:** Allows users to easily change the value (e.g., to "30m") if needed in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new request-timeout configuration option (default: 10 minutes) to control timeout behavior for longer-running operations. Users can customize the timeout duration or disable timeouts by setting the value to "0", providing greater flexibility for extended request processing times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->