### PR TITLE
Increase window height to accomodate Z.AI model

### DIFF
--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -370,7 +370,7 @@ struct SettingsView: View {
                 }
 
                 HStack(spacing: 4) {
-                    Text("© 2025")
+                    Text("© 2026")
                         .font(.caption)
                         .foregroundColor(.secondary)
                     Link("Automaze, Ltd.", destination: URL(string: "https://automaze.io")!)
@@ -394,7 +394,7 @@ struct SettingsView: View {
             }
             .padding(.bottom, 12)
         }
-        .frame(width: 480, height: 680)
+        .frame(width: 480, height: 740)
         .sheet(isPresented: $showingQwenEmailPrompt) {
             VStack(spacing: 16) {
                 Text("Qwen Account Email")


### PR DESCRIPTION
Before: 

- z.ai entry is not visible and the form is not scrollable -> kaboom -> z.ai cannot be configured

<img width="592" height="824" alt="Screenshot 2026-01-15 at 19 57 56" src="https://github.com/user-attachments/assets/33068c11-e8e3-46e7-892e-be7a37fe3c2e" />

After: 

- window height is increased to accommodate z.ai
- z.ai can be configured
- Form becomes scollable when z.ai is expended

<img width="592" height="884" alt="Screenshot 2026-01-15 at 20 08 38" src="https://github.com/user-attachments/assets/b3847ca7-57de-44e0-a2cf-341643628e07" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased main view frame height for improved layout spacing.

* **Chores**
  * Updated copyright year in footer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->