### PR TITLE
Add proxy URL settings UI and config handling

### DIFF
--- a/src/Sources/AppDelegate.swift
+++ b/src/Sources/AppDelegate.swift
@@ -195,7 +195,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
         settingsWindow = window
     }
     
-    func windowDidClose(_ notification: Notification) {
+    func windowWillClose(_ notification: Notification) {
         if notification.object as? NSWindow === settingsWindow {
             settingsWindow = nil
         }

--- a/src/Sources/ServerManager.swift
+++ b/src/Sources/ServerManager.swift
@@ -55,6 +55,12 @@ class ServerManager: ObservableObject {
             UserDefaults.standard.set(enabledProviders, forKey: "enabledProviders")
         }
     }
+    @Published var proxyURL: String = "" {
+        didSet {
+            UserDefaults.standard.set(proxyURL, forKey: "proxyURL")
+        }
+    }
+    private var activeConfigPath: String = ""
 
     /// Vercel AI Gateway configuration for Claude requests
     @Published var vercelGatewayEnabled: Bool = false {
@@ -104,6 +110,9 @@ class ServerManager: ObservableObject {
         }
         vercelGatewayEnabled = UserDefaults.standard.bool(forKey: "vercelGatewayEnabled")
         vercelApiKey = UserDefaults.standard.string(forKey: "vercelApiKey") ?? ""
+        if let savedProxyURL = UserDefaults.standard.string(forKey: "proxyURL") {
+            proxyURL = savedProxyURL
+        }
     }
 
     /// Check if a provider is enabled (defaults to true if not set)
@@ -111,14 +120,41 @@ class ServerManager: ObservableObject {
         return enabledProviders[providerKey] ?? true
     }
 
-    /// Set provider enabled state and regenerate config (hot reload - no restart needed)
+    /// Set provider enabled state and regenerate config (hot reload where possible)
     func setProviderEnabled(_ providerKey: String, enabled: Bool) {
         enabledProviders[providerKey] = enabled
         addLog(enabled ? "✓ Enabled provider: \(providerKey)" : "⚠️ Disabled provider: \(providerKey)")
 
-        // Regenerate config - CLIProxyAPI hot reloads config.yaml automatically
-        _ = getConfigPath()
-        addLog("Config updated (hot reload)")
+        applyConfigUpdate()
+    }
+
+    func setProxyURL(_ url: String) {
+        let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed != proxyURL else { return }
+        proxyURL = trimmed
+        addLog(trimmed.isEmpty ? "Proxy URL cleared" : "Proxy URL updated")
+
+        applyConfigUpdate()
+    }
+
+    private func applyConfigUpdate() {
+        let newConfigPath = getConfigPath()
+        guard !newConfigPath.isEmpty else { return }
+
+        if isRunning {
+            let currentPath = activeConfigPath.isEmpty ? newConfigPath : activeConfigPath
+            if currentPath != newConfigPath {
+                activeConfigPath = newConfigPath
+                addLog("Config path changed; restarting server to apply update")
+                stop { [weak self] in
+                    self?.start { _ in }
+                }
+                return
+            }
+            addLog("Config updated (hot reload)")
+        }
+
+        activeConfigPath = newConfigPath
     }
     
     deinit {
@@ -198,6 +234,7 @@ class ServerManager: ObservableObject {
         
         do {
             try process?.run()
+            activeConfigPath = configPath
             DispatchQueue.main.async {
                 self.isRunning = true
             }
@@ -255,6 +292,7 @@ class ServerManager: ObservableObject {
             DispatchQueue.main.async {
                 self.process = nil
                 self.isRunning = false
+                self.activeConfigPath = ""
                 self.addLog("✓ Server stopped")
                 NotificationCenter.default.post(name: .serverStatusChanged, object: nil)
                 completion?()
@@ -278,8 +316,11 @@ class ServerManager: ObservableObject {
         let authProcess = Process()
         authProcess.executableURL = URL(fileURLWithPath: bundledPath)
         
-        // Get the config path
-        let configPath = (resourcePath as NSString).appendingPathComponent("config.yaml")
+        let configPath = getConfigPath()
+        guard !configPath.isEmpty && FileManager.default.fileExists(atPath: configPath) else {
+            completion(false, "Config not found")
+            return
+        }
         
         var qwenEmail: String?
         
@@ -429,12 +470,12 @@ class ServerManager: ObservableObject {
                     completion(true, "🌐 Browser opened for authentication.\n\nPlease complete the login in your browser.\n\nThe app will automatically detect when you're authenticated.")
                 } else {
                     // Process died quickly - check for error
-                    let outputData = try? outputPipe.fileHandleForReading.readDataToEndOfFile()
-                    let errorData = try? errorPipe.fileHandleForReading.readDataToEndOfFile()
+                    let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                    let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
                     
-                    var output = String(data: outputData ?? Data(), encoding: .utf8) ?? ""
+                    var output = String(data: outputData, encoding: .utf8) ?? ""
                     if output.isEmpty { output = capture.text }
-                    let error = String(data: errorData ?? Data(), encoding: .utf8) ?? ""
+                    let error = String(data: errorData, encoding: .utf8) ?? ""
                     
                     NSLog("[Auth] Process died quickly - output: %@", output.isEmpty ? "(empty)" : String(output.prefix(200)))
                     
@@ -517,7 +558,7 @@ class ServerManager: ObservableObject {
         }
     }
     
-    /// Returns the config path to use, merging bundled config with Z.AI provider and provider exclusions
+    /// Returns the config path to use, merging bundled config with proxy settings, Z.AI provider, and provider exclusions
     func getConfigPath() -> String {
         guard let resourcePath = Bundle.main.resourcePath else {
             return ""
@@ -525,6 +566,12 @@ class ServerManager: ObservableObject {
 
         let bundledConfigPath = (resourcePath as NSString).appendingPathComponent("config.yaml")
         let authDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".cli-proxy-api")
+        let mergedConfigPath = authDir.appendingPathComponent("merged-config.yaml")
+        do {
+            try FileManager.default.createDirectory(at: authDir, withIntermediateDirectories: true)
+        } catch {
+            NSLog("[ServerManager] Failed to create auth directory: %@", error.localizedDescription)
+        }
 
         // Check for Z.AI auth files
         var zaiApiKeys: [String] = []
@@ -546,20 +593,31 @@ class ServerManager: ObservableObject {
             }
         }
 
-        // If no Z.AI keys and no disabled providers, use bundled config
-        guard !zaiApiKeys.isEmpty || !disabledProviders.isEmpty else {
+        let trimmedProxyURL = proxyURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let shouldAddProxy = !trimmedProxyURL.isEmpty
+        let shouldAddProviders = !disabledProviders.isEmpty
+        let shouldAddZai = !zaiApiKeys.isEmpty && isProviderEnabled("zai")
+
+        if !shouldAddProxy && !shouldAddProviders && !shouldAddZai {
+            if FileManager.default.fileExists(atPath: mergedConfigPath.path) {
+                try? FileManager.default.removeItem(at: mergedConfigPath)
+            }
             return bundledConfigPath
         }
 
         // Generate merged config
-        guard let bundledContent = try? String(contentsOfFile: bundledConfigPath, encoding: .utf8) else {
+        guard var bundledContent = try? String(contentsOfFile: bundledConfigPath, encoding: .utf8) else {
             return bundledConfigPath
         }
-        
+
+        if shouldAddProxy {
+            bundledContent = applyProxyURLOverride(to: bundledContent, proxyURL: trimmedProxyURL)
+        }
+
         var additionalConfig = ""
 
         // Build oauth-excluded-models section for disabled providers
-        if !disabledProviders.isEmpty {
+        if shouldAddProviders {
             additionalConfig += """
 
 # Provider exclusions (auto-added by VibeProxy)
@@ -574,7 +632,7 @@ oauth-excluded-models:
         }
 
         // Build Z.AI openai-compatibility section (only if Z.AI is enabled)
-        if !zaiApiKeys.isEmpty && isProviderEnabled("zai") {
+        if shouldAddZai {
             additionalConfig += """
 
 # Z.AI GLM Provider (auto-added by VibeProxy)
@@ -585,12 +643,7 @@ openai-compatibility:
 
 """
             for key in zaiApiKeys {
-                // Escape special YAML characters in double-quoted strings
-                let escapedKey = key
-                    .replacingOccurrences(of: "\\", with: "\\\\")
-                    .replacingOccurrences(of: "\"", with: "\\\"")
-                    .replacingOccurrences(of: "\n", with: "\\n")
-                    .replacingOccurrences(of: "\t", with: "\\t")
+                let escapedKey = escapeYAMLDoubleQuoted(key)
                 additionalConfig += "      - api-key: \"\(escapedKey)\"\n"
             }
             additionalConfig += """
@@ -607,7 +660,6 @@ openai-compatibility:
         }
 
         let mergedContent = bundledContent + additionalConfig
-        let mergedConfigPath = authDir.appendingPathComponent("merged-config.yaml")
         
         do {
             try mergedContent.write(to: mergedConfigPath, atomically: true, encoding: .utf8)
@@ -618,6 +670,35 @@ openai-compatibility:
             NSLog("[ServerManager] Failed to write merged config: %@", error.localizedDescription)
             return bundledConfigPath
         }
+    }
+
+    private func applyProxyURLOverride(to content: String, proxyURL: String) -> String {
+        let escapedURL = escapeYAMLDoubleQuoted(proxyURL)
+        let newLine = "proxy-url: \"\(escapedURL)\""
+        var didReplace = false
+        let lines = content.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+        let updated = lines.map { line -> String in
+            let trimmed = String(line).trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("proxy-url:") {
+                didReplace = true
+                let indent = line.prefix { $0 == " " || $0 == "\t" }
+                return "\(indent)\(newLine)"
+            }
+            return String(line)
+        }
+        var result = updated.joined(separator: "\n")
+        if !didReplace {
+            result += "\n\n# Network proxy (auto-added by VibeProxy)\n\(newLine)\n"
+        }
+        return result
+    }
+
+    private func escapeYAMLDoubleQuoted(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\t", with: "\\t")
     }
     
     func getLogs() -> [String] {

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -244,6 +244,8 @@ struct SettingsView: View {
     @State private var zaiApiKey = ""
     @State private var pendingRefresh: DispatchWorkItem?
     @State private var expandedRowCount = 0
+    @State private var proxyURLInput = ""
+    @State private var isNetworkExpanded = false
     
     private enum Timing {
         static let serverRestartDelay: TimeInterval = 0.3
@@ -255,6 +257,10 @@ struct SettingsView: View {
             return "v\(version)"
         }
         return ""
+    }
+
+    private var trimmedProxyURLInput: String {
+        proxyURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     var body: some View {
@@ -287,6 +293,49 @@ struct SettingsView: View {
                         .onChange(of: launchAtLogin) { _, newValue in
                             toggleLaunchAtLogin(newValue)
                         }
+
+                    DisclosureGroup(isExpanded: $isNetworkExpanded) {
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack(alignment: .center, spacing: 8) {
+                                Text("Proxy URL")
+                                    .frame(width: 80, alignment: .leading)
+                                TextField("", text: $proxyURLInput)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(maxWidth: .infinity)
+                                    .multilineTextAlignment(.leading)
+                            }
+                            HStack(spacing: 8) {
+                                Button("Apply") {
+                                    applyProxyURL()
+                                }
+                                .disabled(trimmedProxyURLInput == serverManager.proxyURL)
+                                Button("Clear") {
+                                    clearProxyURL()
+                                }
+                                .disabled(proxyURLInput.isEmpty && serverManager.proxyURL.isEmpty)
+                                Spacer()
+                            }
+                            Text("Leave empty to disable. Example: http://proxy.local:8080 or socks5://127.0.0.1:1080")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, 6)
+                    } label: {
+                        HStack {
+                            Text("Network")
+                            Spacer()
+                            if !serverManager.proxyURL.isEmpty {
+                                Text("Configured")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            isNetworkExpanded.toggle()
+                        }
+                    }
 
                     HStack {
                         Text("Auth files")
@@ -400,7 +449,6 @@ struct SettingsView: View {
                 }
             }
             .formStyle(.grouped)
-            .scrollDisabled(expandedRowCount == 0)
 
             Spacer()
                 .frame(height: 6)
@@ -451,7 +499,7 @@ struct SettingsView: View {
             }
             .padding(.bottom, 12)
         }
-        .frame(width: 480, height: 740)
+        .frame(width: 480, height: 800)
         .sheet(isPresented: $showingQwenEmailPrompt) {
             VStack(spacing: 16) {
                 Text("Qwen Account Email")
@@ -507,6 +555,8 @@ struct SettingsView: View {
         .onAppear {
             authManager.checkAuthStatus()
             checkLaunchAtLogin()
+            proxyURLInput = serverManager.proxyURL
+            isNetworkExpanded = false
             startMonitoringAuthDirectory()
         }
         .onDisappear {
@@ -524,6 +574,16 @@ struct SettingsView: View {
     private func openAuthFolder() {
         let authDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".cli-proxy-api")
         NSWorkspace.shared.open(authDir)
+    }
+
+    private func applyProxyURL() {
+        serverManager.setProxyURL(proxyURLInput)
+        proxyURLInput = serverManager.proxyURL
+    }
+
+    private func clearProxyURL() {
+        proxyURLInput = ""
+        applyProxyURL()
     }
 
     private func toggleLaunchAtLogin(_ enabled: Bool) {


### PR DESCRIPTION
## Summary
- add Network section with proxy URL field in settings
- persist proxy URL and merge config into ~/.cli-proxy-api/merged-config.yaml when needed
- avoid creating merged config when no overrides are set
- restart server automatically when the config path changes

<img width="592" height="940" alt="Screenshot 2026-01-23 at 23 58 01" src="https://github.com/user-attachments/assets/b426e7f4-b874-441e-bf61-417ea394ddde" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added network proxy configuration in settings with options to apply, clear, and view configuration status
  * Proxy settings now persist automatically across sessions

* **Refactor**
  * Improved window closure event handling in the application lifecycle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->