### PR TITLE
feat: per-account disable/enable toggle for multi-account providers

### DIFF
--- a/src/Sources/AuthStatus.swift
+++ b/src/Sources/AuthStatus.swift
@@ -30,6 +30,7 @@ struct AuthAccount: Identifiable, Equatable {
     let type: ServiceType
     let expired: Date?
     let filePath: URL
+    let isDisabled: Bool
     
     var isExpired: Bool {
         guard let expired = expired else { return false }
@@ -124,13 +125,16 @@ class AuthManager: ObservableObject {
                     }
                 }
                 
+                let isDisabled = json["disabled"] as? Bool ?? false
+                
                 let account = AuthAccount(
                     id: file.lastPathComponent,
                     email: email,
                     login: login,
                     type: serviceType,
                     expired: expiredDate,
-                    filePath: file
+                    filePath: file,
+                    isDisabled: isDisabled
                 )
                 
                 newAccounts[serviceType]?.append(account)
@@ -153,6 +157,34 @@ class AuthManager: ObservableObject {
                     self.serviceAccounts[type] = ServiceAccounts(type: type)
                 }
             }
+        }
+    }
+    
+    /// Toggle the disabled state of a specific account's auth file
+    func toggleAccountDisabled(_ account: AuthAccount) -> Bool {
+        do {
+            let data = try Data(contentsOf: account.filePath)
+            guard var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                NSLog("[AuthStatus] Failed to parse auth file as JSON: %@", account.filePath.path)
+                return false
+            }
+            let currentlyDisabled = json["disabled"] as? Bool ?? false
+            if !currentlyDisabled {
+                let enabledCount = serviceAccounts[account.type]?.accounts.filter { !$0.isDisabled }.count ?? 0
+                guard enabledCount > 1 else {
+                    NSLog("[AuthStatus] Refusing to disable last enabled account for %@", account.type.rawValue)
+                    return false
+                }
+            }
+            json["disabled"] = !currentlyDisabled
+            let updatedData = try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
+            try updatedData.write(to: account.filePath, options: .atomic)
+            NSLog("[AuthStatus] Toggled disabled=%d for: %@", !currentlyDisabled, account.filePath.path)
+            checkAuthStatus()
+            return true
+        } catch {
+            NSLog("[AuthStatus] Failed to toggle disabled state: %@", error.localizedDescription)
+            return false
         }
     }
     

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -1,24 +1,49 @@
 import SwiftUI
 import ServiceManagement
 
-/// A single account row with remove button
+/// A single account row with disable toggle and remove button
 struct AccountRowView: View {
     let account: AuthAccount
     let removeColor: Color
+    let showDisableToggle: Bool
+    let isLastEnabled: Bool
+    let onToggleDisabled: () -> Void
     let onRemove: () -> Void
     
     var body: some View {
         HStack(spacing: 8) {
             Circle()
-                .fill(account.isExpired ? Color.orange : Color.green)
+                .fill(account.isDisabled ? Color.gray : (account.isExpired ? Color.orange : Color.green))
                 .frame(width: 6, height: 6)
             Text(account.displayName)
                 .font(.caption)
-                .foregroundColor(account.isExpired ? .orange : .secondary)
-            if account.isExpired {
+                .foregroundColor(account.isDisabled ? .secondary.opacity(0.5) : (account.isExpired ? .orange : .secondary))
+                .strikethrough(account.isDisabled)
+            if account.isExpired && !account.isDisabled {
                 Text("(expired)")
                     .font(.caption2)
                     .foregroundColor(.orange)
+            }
+            if account.isDisabled {
+                Text("(disabled)")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+            if showDisableToggle {
+                let canDisable = account.isDisabled || !isLastEnabled
+                Button(action: onToggleDisabled) {
+                    Text(account.isDisabled ? "Enable" : "Disable")
+                        .font(.caption)
+                        .foregroundColor(account.isDisabled ? .green : (canDisable ? .orange : .secondary.opacity(0.4)))
+                }
+                .buttonStyle(.plain)
+                .disabled(!canDisable)
+                .help(!canDisable ? "At least one account must remain enabled" : "")
+                .onHover { inside in
+                    if canDisable {
+                        if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                    }
+                }
             }
             Button(action: onRemove) {
                 HStack(spacing: 2) {
@@ -30,7 +55,6 @@ struct AccountRowView: View {
                 .foregroundColor(removeColor)
             }
             .buttonStyle(.plain)
-            .padding(.leading, 8)
             .onHover { inside in
                 if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
             }
@@ -96,6 +120,7 @@ struct ServiceRow<ExtraContent: View>: View {
     let customTitle: String?
     let onConnect: () -> Void
     let onDisconnect: (AuthAccount) -> Void
+    let onToggleDisabled: (AuthAccount) -> Void
     let onToggleEnabled: (Bool) -> Void
     var onExpandChange: ((Bool) -> Void)? = nil
     @ViewBuilder var extraContent: () -> ExtraContent
@@ -150,6 +175,7 @@ struct ServiceRow<ExtraContent: View>: View {
             
             // Account display (only shown when enabled)
             if isEnabled {
+                let enabledCount = accounts.filter { !$0.isDisabled }.count
                 if !accounts.isEmpty {
                     // Collapsible summary
                     HStack(spacing: 4) {
@@ -157,7 +183,7 @@ struct ServiceRow<ExtraContent: View>: View {
                             .font(.caption)
                             .foregroundColor(.green)
 
-                        if accounts.count > 1 {
+                        if enabledCount > 1 {
                             Text("• Round-robin w/ auto-failover")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
@@ -179,7 +205,9 @@ struct ServiceRow<ExtraContent: View>: View {
                     if isExpanded {
                         VStack(alignment: .leading, spacing: 6) {
                             ForEach(accounts) { account in
-                                AccountRowView(account: account, removeColor: removeColor) {
+                                AccountRowView(account: account, removeColor: removeColor, showDisableToggle: accounts.count > 1, isLastEnabled: !account.isDisabled && enabledCount <= 1, onToggleDisabled: {
+                                    onToggleDisabled(account)
+                                }) {
                                     accountToRemove = account
                                     showingRemoveConfirmation = true
                                 }
@@ -308,6 +336,7 @@ struct SettingsView: View {
                         customTitle: nil,
                         onConnect: { connectService(.antigravity) },
                         onDisconnect: { account in disconnectAccount(account) },
+                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("antigravity", enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
@@ -322,6 +351,7 @@ struct SettingsView: View {
                         customTitle: serverManager.vercelGatewayEnabled && !serverManager.vercelApiKey.isEmpty ? "Claude Code (via Vercel)" : nil,
                         onConnect: { connectService(.claude) },
                         onDisconnect: { account in disconnectAccount(account) },
+                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("claude", enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) {
@@ -338,6 +368,7 @@ struct SettingsView: View {
                         customTitle: nil,
                         onConnect: { connectService(.codex) },
                         onDisconnect: { account in disconnectAccount(account) },
+                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("codex", enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
@@ -352,6 +383,7 @@ struct SettingsView: View {
                         customTitle: nil,
                         onConnect: { connectService(.gemini) },
                         onDisconnect: { account in disconnectAccount(account) },
+                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("gemini", enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
@@ -366,6 +398,7 @@ struct SettingsView: View {
                         customTitle: nil,
                         onConnect: { connectService(.copilot) },
                         onDisconnect: { account in disconnectAccount(account) },
+                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("github-copilot", enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
@@ -380,6 +413,7 @@ struct SettingsView: View {
                         customTitle: nil,
                         onConnect: { showingQwenEmailPrompt = true },
                         onDisconnect: { account in disconnectAccount(account) },
+                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("qwen", enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
@@ -394,6 +428,7 @@ struct SettingsView: View {
                         customTitle: nil,
                         onConnect: { showingZaiApiKeyPrompt = true },
                         onDisconnect: { account in disconnectAccount(account) },
+                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("zai", enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
@@ -520,6 +555,20 @@ struct SettingsView: View {
     }
 
     // MARK: - Actions
+    
+    private func toggleAccountDisabled(_ account: AuthAccount) {
+        if authManager.toggleAccountDisabled(account) {
+            authResultSuccess = true
+            authResultMessage = account.isDisabled
+                ? "✓ Enabled \(account.displayName)"
+                : "✓ Disabled \(account.displayName)"
+            showingAuthResult = true
+        } else {
+            authResultSuccess = false
+            authResultMessage = "Failed to update \(account.displayName). Please try again."
+            showingAuthResult = true
+        }
+    }
     
     private func openAuthFolder() {
         let authDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".cli-proxy-api")


### PR DESCRIPTION
## Summary

When multiple accounts are connected for the same provider (e.g., two Claude accounts), users currently have no way to control which accounts are active -- all accounts participate in round-robin. This PR adds a per-account Disable/Enable toggle so users can selectively deactivate individual accounts without removing them.

## What it does

- Adds a **Disable/Enable** button on each account row (only shown when 2+ accounts exist for a provider)
- Disabled accounts show visual indicators: gray status dot, strikethrough name, "(disabled)" label
- Toggling writes `"disabled": true/false` to the account's credential JSON file, which CLIProxyAPIPlus already respects (disabled auths are [skipped during credential selection](https://github.com/router-for-me/CLIProxyAPIPlus/blob/main/sdk/cliproxy/auth/conductor.go))
- **Guard:** the last remaining enabled account cannot be disabled, preventing accidental lockout
- Single-account providers are unaffected (the existing provider-level toggle already handles that case)

## Files changed

| File | Change |
|------|--------|
| `SettingsView.swift` | `AccountRowView` gains disable toggle + visual states; `ServiceRow` computes enabled count and passes guard flag |
| `AuthStatus.swift` | `AuthAccount` gains `isDisabled` field; `AuthManager` gains `toggleAccountDisabled()` that reads/writes the credential JSON |

## Use cases

- **"I want to use only my work account"** -- disable personal account, keep work account enabled
- **"One account is rate-limited"** -- disable it temporarily, re-enable later
- **Pairs with round-robin** -- round-robin only rotates across enabled accounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can disable and re-enable individual accounts from Settings.
  * Disabled accounts are marked "(disabled)" and visually styled (status color, text/strikethrough).
  * Disable/Enable buttons added per account with hover and accessibility text.
  * Prevents disabling the last enabled account and shows helper text when applicable.
  * Disabled state is saved and persists across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->