### PR TITLE
add github copilot models to factory setup guide

### DIFF
--- a/FACTORY_SETUP.md
+++ b/FACTORY_SETUP.md
@@ -21,6 +21,7 @@ VibeProxy manages OAuth tokens, auto-refreshes them, routes requests, and handle
 - Active **ChatGPT Plus/Pro** subscription for OpenAI Codex access
 - **Google account** for Antigravity access (provides Gemini 3 Pro models - optional)
 - **Google Cloud account** with Gemini API access for Gemini 2.x models (optional)
+- **GitHub Copilot** subscription for Copilot model access (optional) — gives Claude, GPT, and Gemini models via GitHub's API
 - **Z.AI API key** for GLM model access (optional) - get one at [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list)
 - Factory CLI installed: `curl -fsSL https://app.factory.ai/cli | sh`
 
@@ -54,7 +55,11 @@ Once VibeProxy is running:
    - Select a Google Cloud project (or accept the default)
    - This provides access to **Gemini 2.x** models
    - VibeProxy will automatically save your credentials
-7. **(Optional)** Click **"Add Account"** next to Z.AI GLM
+7. **(Optional)** Click **"Connect"** next to GitHub Copilot
+   - Authenticate with your GitHub account
+   - Requires an active GitHub Copilot subscription
+   - This provides access to **Claude Opus 4.6, Sonnet 4.6, Haiku 4.5, GPT-5.3-Codex, and Gemini 3 Pro** via GitHub's API
+8. **(Optional)** Click **"Add Account"** next to Z.AI GLM
    - Enter your Z.AI API key (get one at [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list))
    - This provides access to **GLM-4.7** and other GLM models
    - VibeProxy will securely store your API key
@@ -142,6 +147,42 @@ Edit your Factory configuration file at `~/.factory/config.json` (if the file do
     {
       "model_display_name": "AG: Sonnet 4.5",
       "model": "gemini-claude-sonnet-4-5",
+      "base_url": "http://localhost:8317/v1",
+      "api_key": "dummy-not-used",
+      "provider": "openai"
+    },
+
+    {
+      "model_display_name": "GH: Opus 4.6 (via Copilot)",
+      "model": "claude-opus-4.6",
+      "base_url": "http://localhost:8317/v1",
+      "api_key": "dummy-not-used",
+      "provider": "openai"
+    },
+    {
+      "model_display_name": "GH: Sonnet 4.6 (via Copilot)",
+      "model": "claude-sonnet-4.6",
+      "base_url": "http://localhost:8317/v1",
+      "api_key": "dummy-not-used",
+      "provider": "openai"
+    },
+    {
+      "model_display_name": "GH: Haiku 4.5 (via Copilot)",
+      "model": "claude-haiku-4.5",
+      "base_url": "http://localhost:8317/v1",
+      "api_key": "dummy-not-used",
+      "provider": "openai"
+    },
+    {
+      "model_display_name": "GH: GPT-5.3-Codex (via Copilot)",
+      "model": "gpt-5.3-codex",
+      "base_url": "http://localhost:8317/v1",
+      "api_key": "dummy-not-used",
+      "provider": "openai"
+    },
+    {
+      "model_display_name": "GH: Gemini 3 Pro (via Copilot)",
+      "model": "gemini-3-pro-preview",
       "base_url": "http://localhost:8317/v1",
       "api_key": "dummy-not-used",
       "provider": "openai"
@@ -314,6 +355,7 @@ Edit your Factory configuration file at `~/.factory/config.json` (if the file do
    Then choose from:
    - `claude-opus-4-5` (Claude Opus 4.5 - Most powerful)
    - `claude-sonnet-4-5` (Claude 4.5 Sonnet)
+   - `claude-opus-4.6` (Claude Opus 4.6 via Copilot)
    - `gpt-5.1`, `gpt-5.1-codex`, etc.
    - `gemini-3-pro-preview`, `gemini-3-pro-image-preview`, `gemini-2.5-pro`, etc.
 
@@ -330,6 +372,22 @@ Edit your Factory configuration file at `~/.factory/config.json` (if the file do
     - `*-thinking-4000` - "Think" mode (~4K tokens)
     - `*-thinking-10000` - "Think harder" mode (~10K tokens)
     - `*-thinking-32000` - "Ultra think" mode (~32K tokens)
+
+### GitHub Copilot Models
+
+If you have a GitHub Copilot subscription, VibeProxy can route requests through GitHub's API, giving you access to many of the same models via a separate quota.
+
+**Key models:**
+- `claude-opus-4.6` - Claude Opus 4.6 (3x rate)
+- `claude-sonnet-4.6` - Claude Sonnet 4.6 (1x rate, default in Copilot)
+- `claude-haiku-4.5` - Claude Haiku 4.5 (0.33x rate, fast)
+- `gpt-5.3-codex` - GPT-5.3 Codex (1x rate)
+- `gemini-3-pro-preview` - Gemini 3 Pro (1x rate)
+
+> [!NOTE]
+> Copilot model names use **dot-notation** (`claude-opus-4.6`) while Claude Code subscription models use dash-notation (`claude-opus-4-6`). Both work through VibeProxy but route through different auth backends. Use `provider: "openai"` and `base_url` with `/v1` for Copilot models.
+
+**Discovering new model names:** Run `copilot --help` and check the `--model` option for the current list of available models.
 
 ### Gemini Models
 
@@ -419,7 +477,7 @@ No manual CLIProxyAPI update is required—VibeProxy automatically keeps CLIProx
 ### Verification Checklist
 
 1. ✅ VibeProxy is running (menu bar icon shows green)
-2. ✅ Services (Claude, Codex, and optionally Gemini) show as "Connected" in settings
+2. ✅ Services (Claude, Codex, and optionally Gemini/Copilot) show as "Connected" in settings
 3. ✅ Factory CLI config has the custom models configured
 4. ✅ `droid` can select your custom models
 5. ✅ Test with a simple prompt: "what day is it?"


### PR DESCRIPTION
adds copilot section to factory_setup.md — connection steps, config entries, and model list for the 5 main copilot models (opus 4.6, sonnet 4.6, haiku 4.5, gpt-5.3-codex, gemini 3 pro). also mentions how to discover new model names via `copilot --help`. small addition but useful for droid users who have a copilot sub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated setup instructions with GitHub Copilot authentication as an optional prerequisite
* Expanded available models via GitHub Copilot integration (Opus, Sonnet, Haiku, GPT-5.3-Codex, and Gemini 3 Pro)
* Added guidance on Copilot model access, naming conventions, and model discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->