### PR TITLE
fix: restore support for macOS 13 (Ventura)

### DIFF
--- a/src/Info.plist
+++ b/src/Info.plist
@@ -21,7 +21,7 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
+    <string>13.0</string>
     <key>LSUIElement</key>
     <true/>
     <key>NSHighResolutionCapable</key>

--- a/src/Package.swift
+++ b/src/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "CLIProxyMenuBar",
     platforms: [
-        .macOS(.v14)
+        .macOS(.v13)
     ],
     products: [
         .executable(

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -203,12 +203,12 @@ struct ServiceRow<ExtraContent: View>: View {
                 isExpanded = true
             }
         }
-        .onChange(of: accounts) { _, newAccounts in
+        .onChange(of: accounts) { newAccounts in
             if newAccounts.contains(where: { $0.isExpired }) {
                 isExpanded = true
             }
         }
-        .onChange(of: isExpanded) { _, newValue in
+        .onChange(of: isExpanded) { newValue in
             onExpandChange?(newValue)
         }
         .alert("Remove Account", isPresented: $showingRemoveConfirmation) {
@@ -284,7 +284,7 @@ struct SettingsView: View {
 
                 Section {
                     Toggle("Launch at login", isOn: $launchAtLogin)
-                        .onChange(of: launchAtLogin) { _, newValue in
+                        .onChange(of: launchAtLogin) { newValue in
                             toggleLaunchAtLogin(newValue)
                         }
 


### PR DESCRIPTION
- Package.swift: .macOS(.v14) -> .macOS(.v13)
- Info.plist: LSMinimumSystemVersion 14.0 -> 13.0
- SettingsView: use single-closure onChange(of:perform:) for macOS 13