### PR TITLE
feat(vibeproxy): add opt-in fast tier for Codex GPT requests

### DIFF
--- a/src/Sources/AppDelegate.swift
+++ b/src/Sources/AppDelegate.swift
@@ -434,6 +434,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
             enabled: serverManager.vercelGatewayEnabled,
             apiKey: serverManager.vercelApiKey
         )
+        thinkingProxy.forceFastServiceTier = serverManager.forceFastServiceTier
     }
 
     // MARK: - UNUserNotificationCenterDelegate

--- a/src/Sources/ServerManager.swift
+++ b/src/Sources/ServerManager.swift
@@ -69,6 +69,12 @@ class ServerManager: ObservableObject {
             onVercelConfigChanged?()
         }
     }
+    @Published var forceFastServiceTier: Bool = false {
+        didSet {
+            UserDefaults.standard.set(forceFastServiceTier, forKey: "forceFastServiceTier")
+            onVercelConfigChanged?()
+        }
+    }
     var onVercelConfigChanged: (() -> Void)?
 
     /// Helper class to capture output text across closures
@@ -104,6 +110,7 @@ class ServerManager: ObservableObject {
         }
         vercelGatewayEnabled = UserDefaults.standard.bool(forKey: "vercelGatewayEnabled")
         vercelApiKey = UserDefaults.standard.string(forKey: "vercelApiKey") ?? ""
+        forceFastServiceTier = UserDefaults.standard.bool(forKey: "forceFastServiceTier")
     }
 
     /// Check if a provider is enabled (defaults to true if not set)

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -109,6 +109,21 @@ struct VercelGatewayControls: View {
     }
 }
 
+struct RequestDefaultsControls: View {
+    @ObservedObject var serverManager: ServerManager
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle(isOn: $serverManager.forceFastServiceTier) {
+                Text("Force fast tier for GPT requests")
+                    .font(.caption)
+            }
+            .toggleStyle(.checkbox)
+            .help("When enabled, VibeProxy injects Codex fast-mode service_tier into supported GPT and o-series Responses API requests when the client did not already specify a service tier.")
+        }
+    }
+}
+
 /// A row displaying a service with its connected accounts and add button
 struct ServiceRow<ExtraContent: View>: View {
     let serviceType: ServiceType
@@ -371,7 +386,9 @@ struct SettingsView: View {
                         onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("codex", enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
-                    ) { EmptyView() }
+                    ) {
+                        RequestDefaultsControls(serverManager: serverManager)
+                    }
 
                     ServiceRow(
                         serviceType: .gemini,

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -31,6 +31,7 @@ class ThinkingProxy {
     private let stateQueue = DispatchQueue(label: "io.automaze.vibeproxy.thinking-proxy-state")
 
     var vercelConfig = VercelGatewayConfig(enabled: false, apiKey: "")
+    var forceFastServiceTier = false
     
     private enum Config {
         static let hardTokenCap = 32000
@@ -38,6 +39,11 @@ class ThinkingProxy {
         static let headroomRatio = 0.1
         static let vercelGatewayHost = "ai-gateway.vercel.sh"
         static let anthropicVersion = "2023-06-01"
+        static let fastTierEligibleResponsePaths: Set<String> = [
+            "/v1/responses",
+            "/api/v1/responses"
+        ]
+        static let fastTierEligibleModelPrefixes = ["gpt-", "o1", "o3", "o4"]
     }
     
     /**
@@ -268,9 +274,12 @@ class ThinkingProxy {
                 modifiedBody = result.0
                 thinkingEnabled = result.1
             }
-            // Strip cache_control fields that cause 400 errors via the OAuth route
+            // Strip cache_control fields that cause 400 errors via the OAuth route.
             if let stripped = stripCacheControl(from: modifiedBody) {
                 modifiedBody = stripped
+            }
+            if let result = processOpenAIRequestDefaults(jsonString: modifiedBody, path: rewrittenPath) {
+                modifiedBody = result
             }
         }
         
@@ -449,6 +458,49 @@ class ThinkingProxy {
         }
         
         return (jsonString, false)  // No transformation needed
+    }
+
+    /**
+     Injects request defaults for supported GPT/o-series Responses API requests.
+     Currently this only injects the OpenAI wire value for Codex fast mode when
+     enabled and when the client did not explicitly set a service tier.
+     */
+    private func processOpenAIRequestDefaults(jsonString: String, path: String) -> String? {
+        guard forceFastServiceTier,
+              isFastTierEligibleResponsePath(path),
+              let jsonData = jsonString.data(using: .utf8),
+              var json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+              let model = json["model"] as? String else {
+            return nil
+        }
+
+        guard isFastTierEligibleModel(model) else {
+            return jsonString
+        }
+
+        if json["service_tier"] != nil {
+            return jsonString
+        }
+
+        json["service_tier"] = "priority"
+        NSLog("[ThinkingProxy] Injected service_tier=priority for model '\(model)' on path \(path)")
+
+        if let modifiedData = try? JSONSerialization.data(withJSONObject: json),
+           let modifiedString = String(data: modifiedData, encoding: .utf8) {
+            return modifiedString
+        }
+
+        return jsonString
+    }
+
+    private func isFastTierEligibleResponsePath(_ path: String) -> Bool {
+        let normalizedPath = path.split(separator: "?").first.map(String.init) ?? path
+        return Config.fastTierEligibleResponsePaths.contains(normalizedPath)
+    }
+
+    private func isFastTierEligibleModel(_ model: String) -> Bool {
+        let normalizedModel = model.lowercased()
+        return Config.fastTierEligibleModelPrefixes.contains { normalizedModel.starts(with: $0) }
     }
     
     /**


### PR DESCRIPTION
## Summary
- add an opt-in Codex setting to default supported GPT and o-series Responses API requests to Codex fast mode
- show the setting only inside the Codex service section of the VibeProxy UI
- persist the setting and sync it into the existing proxy instance
- apply the rewrite only on Responses API endpoints, and only when the client did not already provide `service_tier`

## Details
This adds a narrowly scoped request-defaults feature for Codex/OpenAI usage through VibeProxy.

When enabled, VibeProxy injects Codex's current fast-mode wire value for supported GPT and o-series model families on Responses API routes. The behavior is intentionally conservative:
- the feature is off by default
- the control is only exposed under the Codex row in the app UI
- it does not override an explicit `service_tier` sent by the client
- it is limited to Responses API requests for supported GPT and o-series model families

## Why
Some Codex/OpenAI clients benefit from fast-tier requests through VibeProxy, but this should be an explicit opt-in feature rather than a default. This change keeps the implementation small, focused, and isolated from unrelated provider behavior.

## Codex behavior reference
This follows Codex's current implementation, where fast mode is serialized to `service_tier = "priority"` on the wire:
- implementation: https://github.com/openai/codex/blob/70eddad6b075f26f0f93c66f7ec9a4e49cdadc93/codex-rs/core/src/client.rs#L590-L593
- HTTP-path assertion: https://github.com/openai/codex/blob/70eddad6b075f26f0f93c66f7ec9a4e49cdadc93/codex-rs/core/tests/suite/model_switching.rs#L288-L292
- WebSocket-path assertion: https://github.com/openai/codex/blob/70eddad6b075f26f0f93c66f7ec9a4e49cdadc93/codex-rs/core/tests/suite/agent_websocket.rs#L292-L294

## Validation
- built successfully with `swift build`
- verified the app bundle builds and launches locally
- reinstalled and relaunched the locally built app for manual testing
