### PR TITLE
Usage monitoring, model groups, and UI enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ When you click "Connect":
 - **Menu Bar Icon**: Shows active/inactive state
 - **Launch at Login**: Toggle to start VibeProxy automatically
 
+### Local Diagnostics API
+
+VibeProxy now exposes a small local diagnostics API on the same proxy port (`http://localhost:8317`):
+
+- `GET /vibe/status` - Account status snapshot from `~/.cli-proxy-api` (active/expired by provider)
+- `GET /vibe/usage` - Request counters since proxy start (by endpoint/provider/model)
+- `POST /vibe/usage/reset` - Reset usage counters
+
+Example:
+
+```bash
+curl http://localhost:8317/vibe/status
+curl http://localhost:8317/vibe/usage
+curl -X POST http://localhost:8317/vibe/usage/reset
+```
+
+> Note: Usage counts are based on inbound proxy requests and model names, not confirmed backend account selection.
+
 ## Requirements
 
 - macOS 13.0 (Ventura) or later

--- a/docs/plans/2026-03-02-model-groups.md
+++ b/docs/plans/2026-03-02-model-groups.md
@@ -1,0 +1,796 @@
+# Model Groups Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let users define virtual model names that round-robin across multiple real models from different providers, with same-request failover.
+
+**Architecture:** New `ModelGroupRouter` in ThinkingProxy intercepts requests for group model names, rewrites the `model` field to the next real model in rotation, and retries on failure with the next model. Groups are configured in Settings UI and persisted via UserDefaults. The `/v1/models` response is intercepted to inject group entries.
+
+**Tech Stack:** Swift, SwiftUI, Network framework (NWConnection), JSONSerialization
+
+---
+
+### Task 1: Create ModelGroup Data Model
+
+**Files:**
+- Create: `src/Sources/ModelGroup.swift`
+
+**Step 1: Create the ModelGroup struct and ModelGroupRouter class**
+
+```swift
+import Foundation
+
+struct ModelGroup: Codable, Identifiable, Equatable {
+    let id: UUID
+    var name: String
+    var models: [String]
+    var enabled: Bool
+
+    init(id: UUID = UUID(), name: String = "", models: [String] = [], enabled: Bool = true) {
+        self.id = id
+        self.name = name
+        self.models = models
+        self.enabled = enabled
+    }
+}
+
+class ModelGroupRouter {
+    private var groups: [ModelGroup] = []
+    private var counters: [UUID: Int] = [:]
+    private let lock = NSLock()
+
+    func updateGroups(_ newGroups: [ModelGroup]) {
+        lock.lock()
+        defer { lock.unlock() }
+        groups = newGroups.filter { $0.enabled && !$0.models.isEmpty }
+        // Prune counters for removed groups
+        let validIds = Set(groups.map(\.id))
+        counters = counters.filter { validIds.contains($0.key) }
+    }
+
+    /// Returns nil if model is not a group name
+    func resolveModel(_ model: String) -> (groupId: UUID, realModel: String)? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let group = groups.first(where: { $0.name == model }) else { return nil }
+        let index = counters[group.id, default: 0] % group.models.count
+        counters[group.id] = index + 1
+        return (group.id, group.models[index])
+    }
+
+    /// Get next model in group, excluding already-tried models. Returns nil when exhausted.
+    func failoverModel(groupId: UUID, excluding tried: Set<String>) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let group = groups.first(where: { $0.id == groupId }) else { return nil }
+        return group.models.first { !tried.contains($0) }
+    }
+
+    /// All enabled group names (for /v1/models injection)
+    func activeGroupNames() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return groups.map(\.name)
+    }
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `cd /Users/yusufisawi/Developer/expirements/vibeproxy/src && swift build 2>&1 | tail -5`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add src/Sources/ModelGroup.swift
+git commit -m "feat: add ModelGroup data model and router"
+```
+
+---
+
+### Task 2: Add ModelGroup Persistence to ServerManager
+
+**Files:**
+- Modify: `src/Sources/ServerManager.swift`
+
+**Step 1: Add modelGroups property with UserDefaults persistence**
+
+After the `vercelApiKey` property (around line 71), add:
+
+```swift
+@Published var modelGroups: [ModelGroup] = [] {
+    didSet {
+        if let data = try? JSONEncoder().encode(modelGroups) {
+            UserDefaults.standard.set(data, forKey: "modelGroups")
+        }
+        onModelGroupsChanged?()
+    }
+}
+
+var onModelGroupsChanged: (() -> Void)?
+```
+
+**Step 2: Load saved groups in init()**
+
+In the `init()` method (around line 107), add after `vercelApiKey` loading:
+
+```swift
+if let data = UserDefaults.standard.data(forKey: "modelGroups"),
+   let saved = try? JSONDecoder().decode([ModelGroup].self, from: data) {
+    modelGroups = saved
+}
+```
+
+**Step 3: Verify it compiles**
+
+Run: `cd /Users/yusufisawi/Developer/expirements/vibeproxy/src && swift build 2>&1 | tail -5`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add src/Sources/ServerManager.swift
+git commit -m "feat: persist model groups in ServerManager via UserDefaults"
+```
+
+---
+
+### Task 3: Wire ModelGroupRouter into ThinkingProxy
+
+**Files:**
+- Modify: `src/Sources/ThinkingProxy.swift`
+
+**Step 1: Add router property to ThinkingProxy**
+
+After `var vercelConfig` (line 43), add:
+
+```swift
+let modelGroupRouter = ModelGroupRouter()
+```
+
+**Step 2: Sync groups from AppDelegate**
+
+In `src/Sources/AppDelegate.swift`, after the `syncVercelConfig()` call (line 39) and its callback (lines 40-42), add:
+
+```swift
+syncModelGroups()
+serverManager.onModelGroupsChanged = { [weak self] in
+    self?.syncModelGroups()
+}
+```
+
+Add the sync method near `syncVercelConfig()` (after line 401):
+
+```swift
+private func syncModelGroups() {
+    thinkingProxy.modelGroupRouter.updateGroups(serverManager.modelGroups)
+}
+```
+
+**Step 3: Verify it compiles**
+
+Run: `cd /Users/yusufisawi/Developer/expirements/vibeproxy/src && swift build 2>&1 | tail -5`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add src/Sources/ThinkingProxy.swift src/Sources/AppDelegate.swift
+git commit -m "feat: wire ModelGroupRouter into ThinkingProxy via AppDelegate"
+```
+
+---
+
+### Task 4: Intercept Requests for Model Groups in processRequest
+
+**Files:**
+- Modify: `src/Sources/ThinkingProxy.swift`
+
+This is the core routing logic. In `processRequest`, after the thinking parameter processing (line 294) and before the usage recording (line 296), we resolve model groups.
+
+**Step 1: Add model group resolution in processRequest**
+
+After line 294 (`}`) and before line 296 (`if isCliProxyUsagePath`), insert:
+
+```swift
+// Resolve model group — rewrite model name to real model via round-robin
+var modelGroupContext: (groupId: UUID, triedModels: Set<String>)? = nil
+if method == "POST" && !modifiedBody.isEmpty {
+    if let resolved = resolveModelGroup(body: modifiedBody) {
+        modifiedBody = resolved.rewrittenBody
+        modelGroupContext = (resolved.groupId, [resolved.realModel])
+        NSLog("[ThinkingProxy] Model group resolved: '\(resolved.groupName)' → '\(resolved.realModel)'")
+    }
+}
+```
+
+**Step 2: Add the resolveModelGroup helper method**
+
+Add this method to ThinkingProxy (near `extractModel` around line 380):
+
+```swift
+private struct ModelGroupResolution {
+    let groupName: String
+    let groupId: UUID
+    let realModel: String
+    let rewrittenBody: String
+}
+
+private func resolveModelGroup(body: String) -> ModelGroupResolution? {
+    guard let data = body.data(using: .utf8),
+          var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let model = json["model"] as? String else {
+        return nil
+    }
+
+    guard let resolved = modelGroupRouter.resolveModel(model) else { return nil }
+
+    json["model"] = resolved.realModel
+    guard let modifiedData = try? JSONSerialization.data(withJSONObject: json),
+          let modifiedString = String(data: modifiedData, encoding: .utf8) else {
+        return nil
+    }
+
+    return ModelGroupResolution(
+        groupName: model,
+        groupId: resolved.groupId,
+        realModel: resolved.realModel,
+        rewrittenBody: modifiedString
+    )
+}
+```
+
+**Step 3: Add a rewriteModelInBody helper for failover retries**
+
+```swift
+private func rewriteModelInBody(_ body: String, to newModel: String) -> String? {
+    guard let data = body.data(using: .utf8),
+          var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        return nil
+    }
+    json["model"] = newModel
+    guard let modified = try? JSONSerialization.data(withJSONObject: json),
+          let result = String(data: modified, encoding: .utf8) else {
+        return nil
+    }
+    return result
+}
+```
+
+**Step 4: Update the forwardRequest call at line 307 to pass group context**
+
+Change line 307 from:
+```swift
+forwardRequest(method: method, path: rewrittenPath, version: httpVersion, headers: headers, body: modifiedBody, thinkingEnabled: thinkingEnabled, originalConnection: connection)
+```
+To:
+```swift
+forwardRequest(method: method, path: rewrittenPath, version: httpVersion, headers: headers, body: modifiedBody, thinkingEnabled: thinkingEnabled, originalConnection: connection, modelGroupContext: modelGroupContext)
+```
+
+**Step 5: Update forwardRequest signature to accept modelGroupContext**
+
+Change line 902 signature to add the optional parameter:
+
+```swift
+private func forwardRequest(method: String, path: String, version: String, headers: [(String, String)], body: String, thinkingEnabled: Bool = false, originalConnection: NWConnection, retryWithApiPrefix: Bool = false, modelGroupContext: (groupId: UUID, triedModels: Set<String>)? = nil) {
+```
+
+And update the `receiveResponse` call at line ~999 (inside the `.ready` state handler). If `modelGroupContext` is set, use the new retry-aware receiver instead:
+
+```swift
+if let groupCtx = modelGroupContext {
+    self.receiveResponseWithGroupFailover(
+        from: targetConnection,
+        originalConnection: originalConnection,
+        method: method, path: path, version: version,
+        headers: headers, body: body,
+        thinkingEnabled: thinkingEnabled,
+        groupContext: groupCtx
+    )
+} else if retryWithApiPrefix {
+    self.receiveResponseWith404Retry(from: targetConnection, originalConnection: originalConnection,
+                                     method: method, path: path, version: version,
+                                     headers: headers, body: body)
+} else {
+    self.receiveResponse(from: targetConnection, originalConnection: originalConnection)
+}
+```
+
+**Step 6: Verify it compiles (will fail until Task 5 adds receiveResponseWithGroupFailover)**
+
+This is expected — we add the failover method in Task 5.
+
+**Step 7: Commit (WIP)**
+
+```bash
+git add src/Sources/ThinkingProxy.swift
+git commit -m "feat(wip): model group resolution in processRequest"
+```
+
+---
+
+### Task 5: Implement Response Failover for Model Groups
+
+**Files:**
+- Modify: `src/Sources/ThinkingProxy.swift`
+
+The key challenge: we need to buffer the initial response to check the HTTP status code. If it's an error (429/500/502/503), retry with the next model. If 200, stream normally.
+
+**Step 1: Add receiveResponseWithGroupFailover method**
+
+```swift
+private func receiveResponseWithGroupFailover(
+    from targetConnection: NWConnection,
+    originalConnection: NWConnection,
+    method: String, path: String, version: String,
+    headers: [(String, String)], body: String,
+    thinkingEnabled: Bool,
+    groupContext: (groupId: UUID, triedModels: Set<String>)
+) {
+    targetConnection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
+        guard let self = self else { return }
+
+        if let error = error {
+            NSLog("[ThinkingProxy] Group failover receive error: \(error)")
+            // Network error — try next model
+            targetConnection.cancel()
+            self.retryWithNextGroupModel(
+                originalConnection: originalConnection,
+                method: method, path: path, version: version,
+                headers: headers, body: body,
+                thinkingEnabled: thinkingEnabled,
+                groupContext: groupContext
+            )
+            return
+        }
+
+        guard let data = data, !data.isEmpty else {
+            targetConnection.cancel()
+            originalConnection.cancel()
+            return
+        }
+
+        // Check HTTP status from first chunk
+        let statusCode = self.extractHttpStatus(from: data)
+        let isRetryable = [429, 500, 502, 503].contains(statusCode)
+
+        if isRetryable {
+            NSLog("[ThinkingProxy] Model group got \(statusCode ?? 0), attempting failover")
+            targetConnection.cancel()
+            self.retryWithNextGroupModel(
+                originalConnection: originalConnection,
+                method: method, path: path, version: version,
+                headers: headers, body: body,
+                thinkingEnabled: thinkingEnabled,
+                groupContext: groupContext
+            )
+        } else {
+            // Success or non-retryable error — forward first chunk then stream rest
+            originalConnection.send(content: data, completion: .contentProcessed({ sendError in
+                if let sendError = sendError {
+                    NSLog("[ThinkingProxy] Send response error: \(sendError)")
+                }
+                if isComplete {
+                    targetConnection.cancel()
+                    originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
+                        originalConnection.cancel()
+                    }))
+                } else {
+                    self.streamNextChunk(from: targetConnection, to: originalConnection)
+                }
+            }))
+        }
+    }
+}
+
+private func retryWithNextGroupModel(
+    originalConnection: NWConnection,
+    method: String, path: String, version: String,
+    headers: [(String, String)], body: String,
+    thinkingEnabled: Bool,
+    groupContext: (groupId: UUID, triedModels: Set<String>)
+) {
+    guard let nextModel = modelGroupRouter.failoverModel(groupId: groupContext.groupId, excluding: groupContext.triedModels),
+          let rewrittenBody = rewriteModelInBody(body, to: nextModel) else {
+        NSLog("[ThinkingProxy] Model group exhausted all models, returning 503")
+        sendError(to: originalConnection, statusCode: 503, message: "All models in group exhausted")
+        return
+    }
+
+    NSLog("[ThinkingProxy] Model group failover → '\(nextModel)'")
+    var updatedContext = groupContext
+    updatedContext.triedModels.insert(nextModel)
+
+    forwardRequest(
+        method: method, path: path, version: version,
+        headers: headers, body: rewrittenBody,
+        thinkingEnabled: thinkingEnabled,
+        originalConnection: originalConnection,
+        modelGroupContext: updatedContext
+    )
+}
+
+private func extractHttpStatus(from data: Data) -> Int? {
+    // Parse "HTTP/1.1 NNN" from first line of response
+    guard let str = String(data: data.prefix(32), encoding: .utf8) else { return nil }
+    let parts = str.components(separatedBy: " ")
+    guard parts.count >= 2, let code = Int(parts[1]) else { return nil }
+    return code
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `cd /Users/yusufisawi/Developer/expirements/vibeproxy/src && swift build 2>&1 | tail -5`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add src/Sources/ThinkingProxy.swift
+git commit -m "feat: model group failover with status-based retry"
+```
+
+---
+
+### Task 6: Inject Model Groups into /v1/models Response
+
+**Files:**
+- Modify: `src/Sources/ThinkingProxy.swift`
+
+For GET `/v1/models`, we need to buffer the full response from CLIProxyAPIPlus, parse JSON, inject group entries, and return.
+
+**Step 1: Add interception in processRequest**
+
+In `processRequest`, before the final `forwardRequest` call (line 307), add a check for the models endpoint:
+
+```swift
+// Intercept /v1/models to inject model groups
+if method == "GET" && (rewrittenPath == "/v1/models" || rewrittenPath == "/api/v1/models") {
+    let groupNames = modelGroupRouter.activeGroupNames()
+    if !groupNames.isEmpty {
+        forwardRequestAndInjectModels(method: method, path: rewrittenPath, version: httpVersion, headers: headers, body: modifiedBody, groupNames: groupNames, originalConnection: connection)
+        return
+    }
+}
+```
+
+**Step 2: Add forwardRequestAndInjectModels method**
+
+```swift
+private func forwardRequestAndInjectModels(method: String, path: String, version: String, headers: [(String, String)], body: String, groupNames: [String], originalConnection: NWConnection) {
+    guard let port = NWEndpoint.Port(rawValue: targetPort) else {
+        sendError(to: originalConnection, statusCode: 500, message: "Internal Server Error")
+        return
+    }
+    let endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(targetHost), port: port)
+    let targetConnection = NWConnection(to: endpoint, using: NWParameters.tcp)
+
+    targetConnection.stateUpdateHandler = { state in
+        switch state {
+        case .ready:
+            var req = "\(method) \(path) \(version)\r\n"
+            let excluded: Set<String> = ["content-length", "host", "transfer-encoding"]
+            for (name, value) in headers where !excluded.contains(name.lowercased()) {
+                req += "\(name): \(value)\r\n"
+            }
+            req += "Host: \(self.targetHost):\(self.targetPort)\r\n"
+            req += "Connection: close\r\n"
+            let contentLength = body.utf8.count
+            req += "Content-Length: \(contentLength)\r\n\r\n\(body)"
+
+            if let data = req.data(using: .utf8) {
+                targetConnection.send(content: data, completion: .contentProcessed({ error in
+                    if let error = error {
+                        NSLog("[ThinkingProxy] Models inject send error: \(error)")
+                        targetConnection.cancel()
+                        originalConnection.cancel()
+                    } else {
+                        self.bufferFullResponse(from: targetConnection) { responseData in
+                            guard let responseData = responseData else {
+                                self.sendError(to: originalConnection, statusCode: 502, message: "Bad Gateway")
+                                return
+                            }
+                            let injected = self.injectGroupModels(into: responseData, groupNames: groupNames)
+                            originalConnection.send(content: injected, completion: .contentProcessed({ _ in
+                                originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
+                                    originalConnection.cancel()
+                                }))
+                            }))
+                        }
+                    }
+                }))
+            }
+        case .failed(let error):
+            NSLog("[ThinkingProxy] Models inject connection failed: \(error)")
+            self.sendError(to: originalConnection, statusCode: 502, message: "Bad Gateway")
+            targetConnection.cancel()
+        default: break
+        }
+    }
+    targetConnection.start(queue: .global(qos: .userInitiated))
+}
+
+private func bufferFullResponse(from connection: NWConnection, accumulated: Data = Data(), completion: @escaping (Data?) -> Void) {
+    connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { data, _, isComplete, error in
+        if let error = error {
+            NSLog("[ThinkingProxy] Buffer response error: \(error)")
+            connection.cancel()
+            completion(nil)
+            return
+        }
+        var buffer = accumulated
+        if let data = data { buffer.append(data) }
+        if isComplete {
+            connection.cancel()
+            completion(buffer)
+        } else {
+            self.bufferFullResponse(from: connection, accumulated: buffer, completion: completion)
+        }
+    }
+}
+
+private func injectGroupModels(into responseData: Data, groupNames: [String]) -> Data {
+    // Split HTTP response into headers and body
+    guard let responseStr = String(data: responseData, encoding: .utf8),
+          let headerEnd = responseStr.range(of: "\r\n\r\n") else {
+        return responseData
+    }
+
+    let bodyStr = String(responseStr[headerEnd.upperBound...])
+    guard let bodyData = bodyStr.data(using: .utf8),
+          var json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any],
+          var dataArray = json["data"] as? [[String: Any]] else {
+        return responseData
+    }
+
+    // Inject group models
+    for name in groupNames {
+        dataArray.append([
+            "id": name,
+            "object": "model",
+            "created": Int(Date().timeIntervalSince1970),
+            "owned_by": "vibeproxy"
+        ])
+    }
+    json["data"] = dataArray
+
+    guard let newBody = try? JSONSerialization.data(withJSONObject: json),
+          let newBodyStr = String(data: newBody, encoding: .utf8) else {
+        return responseData
+    }
+
+    // Rebuild HTTP response with updated Content-Length
+    let newResponse = "HTTP/1.1 200 OK\r\n" +
+        "Content-Type: application/json\r\n" +
+        "Content-Length: \(newBody.count)\r\n" +
+        "Connection: close\r\n" +
+        "\r\n" +
+        newBodyStr
+
+    return newResponse.data(using: .utf8) ?? responseData
+}
+```
+
+**Step 3: Verify it compiles**
+
+Run: `cd /Users/yusufisawi/Developer/expirements/vibeproxy/src && swift build 2>&1 | tail -5`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add src/Sources/ThinkingProxy.swift
+git commit -m "feat: inject model groups into /v1/models response"
+```
+
+---
+
+### Task 7: Build Settings UI for Model Groups
+
+**Files:**
+- Modify: `src/Sources/SettingsView.swift`
+
+**Step 1: Add new "Model Groups" section**
+
+In the Form body, between the `Section("Services")` closing brace (line 515) and `Section("Available Models")` (line 517), add:
+
+```swift
+Section("Model Groups") {
+    if serverManager.modelGroups.isEmpty {
+        Text("No model groups configured")
+            .font(.caption)
+            .foregroundColor(.secondary)
+    } else {
+        ForEach($serverManager.modelGroups) { $group in
+            ModelGroupRow(group: $group, onDelete: {
+                serverManager.modelGroups.removeAll { $0.id == group.id }
+            })
+        }
+    }
+
+    Button(action: {
+        serverManager.modelGroups.append(ModelGroup())
+    }) {
+        HStack(spacing: 4) {
+            Image(systemName: "plus.circle.fill")
+                .font(.caption)
+            Text("Add Model Group")
+                .font(.caption)
+        }
+    }
+    .buttonStyle(.plain)
+    .foregroundColor(.accentColor)
+}
+```
+
+**Step 2: Create ModelGroupRow view**
+
+Add this above the SettingsView struct (near the other helper views like AccountRowView):
+
+```swift
+struct ModelGroupRow: View {
+    @Binding var group: ModelGroup
+    let onDelete: () -> Void
+    @State private var newModelName = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Toggle("", isOn: $group.enabled)
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .controlSize(.mini)
+
+                TextField("Group name", text: $group.name)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12, design: .monospaced))
+                    .frame(maxWidth: 160)
+
+                Spacer()
+
+                Button(action: onDelete) {
+                    Image(systemName: "trash")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+                .buttonStyle(.plain)
+                .onHover { inside in
+                    if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                }
+            }
+
+            // Linked models
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(Array(group.models.enumerated()), id: \.offset) { index, model in
+                    HStack(spacing: 6) {
+                        Text("\(index + 1).")
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundColor(.secondary)
+                            .frame(width: 16, alignment: .trailing)
+                        Text(model)
+                            .font(.system(size: 11, design: .monospaced))
+                        Spacer()
+                        Button(action: {
+                            group.models.remove(at: index)
+                        }) {
+                            Image(systemName: "minus.circle.fill")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .onHover { inside in
+                            if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                        }
+                    }
+                }
+
+                HStack(spacing: 6) {
+                    TextField("Model name (e.g. gpt-5)", text: $newModelName)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 11, design: .monospaced))
+                        .onSubmit { addModel() }
+
+                    Button(action: addModel) {
+                        Image(systemName: "plus.circle.fill")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.accentColor)
+                    .disabled(newModelName.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+            .padding(.leading, 32)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func addModel() {
+        let trimmed = newModelName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        group.models.append(trimmed)
+        newModelName = ""
+    }
+}
+```
+
+**Step 3: Update window height to accommodate new section**
+
+Change the frame height (line 644) from 780 to 860:
+
+```swift
+.frame(width: 480, height: 860)
+```
+
+**Step 4: Verify it compiles**
+
+Run: `cd /Users/yusufisawi/Developer/expirements/vibeproxy/src && swift build 2>&1 | tail -5`
+Expected: Build succeeds
+
+**Step 5: Commit**
+
+```bash
+git add src/Sources/SettingsView.swift
+git commit -m "feat: model groups settings UI"
+```
+
+---
+
+### Task 8: Update providerForModel for Model Groups
+
+**Files:**
+- Modify: `src/Sources/ThinkingProxy.swift`
+
+The `providerForModel` function is used for usage tracking. When a request uses a model group, usage should be tracked under the real model's provider, not "other". Since we rewrite the model before `recordUsage` is called, this should already work. However, we should also handle the case where the original group name shows up.
+
+**Step 1: Update providerForModel to check groups**
+
+At the top of `providerForModel`, add:
+
+```swift
+if modelGroupRouter.resolveModel(lower) != nil {
+    return "vibeproxy-group"
+}
+```
+
+Actually — since the model is already rewritten to the real model before `recordUsage` is called (resolution happens at line ~296, usage at ~298), the provider will be correctly detected from the real model name. No change needed here.
+
+**Step 1: Verify end-to-end flow manually**
+
+Run: `cd /Users/yusufisawi/Developer/expirements/vibeproxy/src && swift build 2>&1 | tail -5`
+Expected: Build succeeds
+
+**Step 2: Test manually**
+
+1. Launch the app
+2. Go to Settings → Model Groups
+3. Create a group named "high" with models: `gpt-5`, `claude-sonnet-4-5-20250929`
+4. Enable it
+5. Check `/v1/models` — verify "high" appears with owned_by "vibeproxy"
+6. Send a request with `"model": "high"` — verify it reaches one of the real models
+7. Send multiple requests — verify round-robin alternation in logs
+8. Disable one provider to force failure — verify failover to next model
+
+**Step 3: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: complete model groups with round-robin and failover"
+```
+
+---
+
+## Testing Checklist
+
+- [ ] Model group appears in /v1/models alongside real models
+- [ ] Request with group name rewrites to real model (check NSLog output)
+- [ ] Round-robin alternates between models across requests
+- [ ] On 429/500/502/503, automatically retries with next model in group
+- [ ] When all models in group fail, returns 503
+- [ ] Disabling a group removes it from /v1/models
+- [ ] Groups persist across app restarts (UserDefaults)
+- [ ] Empty group name or models list is handled gracefully
+- [ ] Thinking suffix still works on real models resolved from groups
+- [ ] Usage tracking shows the real model name, not the group name

--- a/docs/plans/2026-03-03-jean-ice-compatibility-core-parity.md
+++ b/docs/plans/2026-03-03-jean-ice-compatibility-core-parity.md
@@ -1,0 +1,901 @@
+# Jean ICE Compatibility-Core Parity Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build full cross-platform feature parity in Jean ICE using `cli-proxy-api-plus` as the auth/routing engine and a Jean edge proxy layer for compatibility behavior.
+
+**Architecture:** Jean runs a Rust edge proxy on a user-facing port and launches `cli-proxy-api-plus` as a managed sidecar on an internal port. The edge proxy owns request/response compatibility transforms (thinking/reasoning, model groups, qualified model IDs, diagnostics), while the sidecar owns provider auth and base upstream routing. Frontend (Tauri/React) controls settings, account management, and observability.
+
+**Tech Stack:** Tauri v2, Rust (`tokio`, `axum`/`hyper`, `serde`, `reqwest`), TypeScript/React, Vitest, Playwright, sidecar packaging.
+
+---
+
+## Compatibility Contract (must be true before release)
+
+1. Jean accepts OpenAI-compatible `/v1/*` requests and Claude-compatible message flows without changing client integrations.
+2. Jean preserves provider auth/account behavior by using `~/.cli-proxy-api` and `cli-proxy-api-plus` login modes.
+3. Jean supports providers: Claude, Codex/OpenAI, GitHub Copilot, Gemini, Qwen, Antigravity, Z.AI.
+4. Jean supports proxy toggle, start-with-app, and configurable public proxy port.
+5. Jean supports manual model groups with round-robin and same-request failover.
+6. Jean supports qualified model IDs `{owned_by}/{model_id}` and provider-pinned routing.
+7. Jean supports reasoning transforms (`-thinking-*`, `-reasoning-*`) and diagnostics APIs (`/vibe/status`, `/vibe/usage`, `/vibe/usage/reset`).
+8. Jean tracks usage and account rotation state (including next account index) and exposes it in diagnostics + UI.
+
+Execution discipline during implementation: `@superpowers:test-driven-development`, `@superpowers:systematic-debugging`, `@superpowers:verification-before-completion`.
+
+---
+
+### Task 1: Create Jean Proxy Core Module Skeleton
+
+**Files:**
+- Create: `jean/src-tauri/src/lib.rs`
+- Create: `jean/src-tauri/src/app_state.rs`
+- Create: `jean/src-tauri/src/proxy/mod.rs`
+- Create: `jean/src-tauri/src/commands/mod.rs`
+- Test: `jean/src-tauri/tests/app_state_bootstrap.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+use jean_ice::app_state::AppState;
+
+#[test]
+fn app_state_starts_with_proxy_disabled() {
+    let state = AppState::new_for_test();
+    assert!(!state.runtime.proxy_enabled());
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test app_state_bootstrap`
+Expected: FAIL with unresolved import/module errors.
+
+**Step 3: Write minimal implementation**
+
+```rust
+pub mod app_state;
+
+pub struct RuntimeState { enabled: bool }
+impl RuntimeState {
+    pub fn proxy_enabled(&self) -> bool { self.enabled }
+}
+
+pub struct AppState { pub runtime: RuntimeState }
+impl AppState {
+    pub fn new_for_test() -> Self {
+        Self { runtime: RuntimeState { enabled: false } }
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test app_state_bootstrap`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/lib.rs jean/src-tauri/src/app_state.rs jean/src-tauri/src/proxy/mod.rs jean/src-tauri/src/commands/mod.rs jean/src-tauri/tests/app_state_bootstrap.rs
+git commit -m "chore: scaffold jean proxy core modules"
+```
+
+---
+
+### Task 2: Implement Persistent Settings (Proxy Toggle, Autostart, Port Override)
+
+**Files:**
+- Create: `jean/src-tauri/src/settings.rs`
+- Modify: `jean/src-tauri/src/app_state.rs`
+- Test: `jean/src-tauri/tests/settings_persistence.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+use jean_ice::settings::{AppSettings, SettingsStore};
+
+#[test]
+fn saves_and_loads_proxy_settings() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SettingsStore::new_for_path(dir.path().join("settings.json"));
+
+    let expected = AppSettings {
+        proxy_enabled: true,
+        start_with_app: true,
+        public_proxy_port: 8317,
+        ..Default::default()
+    };
+
+    store.save(&expected).unwrap();
+    let loaded = store.load().unwrap();
+    assert_eq!(loaded.public_proxy_port, 8317);
+    assert!(loaded.start_with_app);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test settings_persistence`
+Expected: FAIL with missing `settings` module/types.
+
+**Step 3: Write minimal implementation**
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AppSettings {
+    pub proxy_enabled: bool,
+    pub start_with_app: bool,
+    pub public_proxy_port: u16,
+    pub backend_port: u16,
+    pub enabled_providers: std::collections::BTreeMap<String, bool>,
+    pub vercel_gateway_enabled: bool,
+    pub vercel_api_key: String,
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            proxy_enabled: false,
+            start_with_app: false,
+            public_proxy_port: 8317,
+            backend_port: 8318,
+            enabled_providers: BTreeMap::new(),
+            vercel_gateway_enabled: false,
+            vercel_api_key: String::new(),
+        }
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test settings_persistence`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/settings.rs jean/src-tauri/src/app_state.rs jean/src-tauri/tests/settings_persistence.rs
+git commit -m "feat: add persistent settings for proxy runtime"
+```
+
+---
+
+### Task 3: Add Sidecar Process Manager for `cli-proxy-api-plus`
+
+**Files:**
+- Create: `jean/src-tauri/src/process/sidecar_manager.rs`
+- Modify: `jean/src-tauri/src/app_state.rs`
+- Test: `jean/src-tauri/tests/sidecar_manager.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+use jean_ice::process::sidecar_manager::SidecarManager;
+
+#[tokio::test]
+async fn start_sets_running_state() {
+    let mgr = SidecarManager::new_for_test();
+    mgr.mark_started_for_test();
+    assert!(mgr.is_running().await);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test sidecar_manager`
+Expected: FAIL with missing process module.
+
+**Step 3: Write minimal implementation**
+
+```rust
+pub struct SidecarManager { running: tokio::sync::RwLock<bool> }
+impl SidecarManager {
+    pub fn new_for_test() -> Self { Self { running: tokio::sync::RwLock::new(false) } }
+    pub async fn is_running(&self) -> bool { *self.running.read().await }
+    pub fn mark_started_for_test(&self) { futures::executor::block_on(async { *self.running.write().await = true; }); }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test sidecar_manager`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/process/sidecar_manager.rs jean/src-tauri/src/app_state.rs jean/src-tauri/tests/sidecar_manager.rs
+git commit -m "feat: add sidecar manager lifecycle state"
+```
+
+---
+
+### Task 4: Implement Auth Filesystem Model (`~/.cli-proxy-api` parity)
+
+**Files:**
+- Create: `jean/src-tauri/src/auth/service_type.rs`
+- Create: `jean/src-tauri/src/auth/account_store.rs`
+- Test: `jean/src-tauri/tests/auth_account_store.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+use jean_ice::auth::account_store::AccountStore;
+
+#[test]
+fn scans_active_and_disabled_accounts() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = AccountStore::new_for_base(dir.path());
+    store.seed_fixture_account("claude", "user@example.com");
+    let snapshot = store.scan().unwrap();
+    assert_eq!(snapshot.providers["claude"].active.len(), 1);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test auth_account_store`
+Expected: FAIL with missing auth store.
+
+**Step 3: Write minimal implementation**
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ServiceType { Claude, Codex, GithubCopilot, Gemini, Qwen, Antigravity, Zai }
+
+pub struct AccountStore { base: PathBuf }
+impl AccountStore {
+    pub fn scan(&self) -> anyhow::Result<AccountSnapshot> { /* parse active/.disabled/.auto */ }
+    pub fn disable_account(&self, filename: &str) -> anyhow::Result<()> { /* move to .disabled */ }
+    pub fn auto_disable_account(&self, filename: &str) -> anyhow::Result<()> { /* move to .disabled/.auto */ }
+    pub fn restore_account(&self, filename: &str) -> anyhow::Result<()> { /* move back to active */ }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test auth_account_store`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/auth/service_type.rs jean/src-tauri/src/auth/account_store.rs jean/src-tauri/tests/auth_account_store.rs
+git commit -m "feat: add cli-proxy auth account store parity"
+```
+
+---
+
+### Task 5: Implement Provider Login Command Runner
+
+**Files:**
+- Create: `jean/src-tauri/src/auth/login_runner.rs`
+- Modify: `jean/src-tauri/src/process/sidecar_manager.rs`
+- Test: `jean/src-tauri/tests/login_runner_args.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+use jean_ice::auth::login_runner::{AuthCommand, build_args};
+
+#[test]
+fn maps_provider_to_cli_proxy_flags() {
+    assert_eq!(build_args(AuthCommand::ClaudeLogin, "config.yaml"), vec!["--config", "config.yaml", "-claude-login"]);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test login_runner_args`
+Expected: FAIL with missing auth runner.
+
+**Step 3: Write minimal implementation**
+
+```rust
+pub enum AuthCommand {
+    ClaudeLogin,
+    CodexLogin,
+    CopilotLogin,
+    GeminiLogin,
+    QwenLogin { email: String },
+    AntigravityLogin,
+    ZaiApiKey { api_key: String },
+}
+
+pub fn build_args(cmd: AuthCommand, config: &str) -> Vec<&str> { /* exact flag mapping */ }
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test login_runner_args`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/auth/login_runner.rs jean/src-tauri/src/process/sidecar_manager.rs jean/src-tauri/tests/login_runner_args.rs
+git commit -m "feat: add provider auth command runner"
+```
+
+---
+
+### Task 6: Implement Merged Config Builder (Provider Exclusion + Z.AI)
+
+**Files:**
+- Create: `jean/src-tauri/src/config/merged_config.rs`
+- Test: `jean/src-tauri/tests/merged_config.rs`
+- Modify: `jean/src-tauri/src/process/sidecar_manager.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+use jean_ice::config::merged_config::build_merged_config;
+
+#[test]
+fn injects_oauth_excluded_models_and_zai_entries() {
+    let merged = build_merged_config(
+        "port: 8318\n",
+        &["claude".into()],
+        &["zai-key-123".into()],
+        true,
+    );
+    assert!(merged.contains("oauth-excluded-models"));
+    assert!(merged.contains("openai-compatibility"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test merged_config`
+Expected: FAIL with missing config builder.
+
+**Step 3: Write minimal implementation**
+
+```rust
+pub fn build_merged_config(base_yaml: &str, disabled: &[String], zai_keys: &[String], zai_enabled: bool) -> String {
+    // append oauth-excluded-models and optional zai openai-compatibility block
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test merged_config`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/config/merged_config.rs jean/src-tauri/src/process/sidecar_manager.rs jean/src-tauri/tests/merged_config.rs
+git commit -m "feat: add merged cli-proxy config generation"
+```
+
+---
+
+### Task 7: Implement Edge Proxy Core (Pass-through + Diagnostics Endpoints)
+
+**Files:**
+- Create: `jean/src-tauri/src/proxy/server.rs`
+- Create: `jean/src-tauri/src/proxy/diagnostics.rs`
+- Test: `jean/src-tauri/tests/proxy_diagnostics.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn usage_reset_endpoint_returns_ok() {
+    let app = jean_ice::proxy::server::build_test_router();
+    let res = app.oneshot(http::Request::post("/vibe/usage/reset").body(axum::body::Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(res.status(), http::StatusCode::OK);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test proxy_diagnostics`
+Expected: FAIL with missing proxy router.
+
+**Step 3: Write minimal implementation**
+
+```rust
+pub fn build_router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/vibe/status", get(status_handler))
+        .route("/vibe/usage", get(usage_handler))
+        .route("/vibe/usage/reset", post(reset_usage_handler))
+        .fallback(any(forward_handler))
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test proxy_diagnostics`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/proxy/server.rs jean/src-tauri/src/proxy/diagnostics.rs jean/src-tauri/tests/proxy_diagnostics.rs
+git commit -m "feat: add edge proxy server with diagnostics endpoints"
+```
+
+---
+
+### Task 8: Implement API Compatibility and Amp Routing Rules
+
+**Files:**
+- Create: `jean/src-tauri/src/proxy/path_rewrite.rs`
+- Modify: `jean/src-tauri/src/proxy/server.rs`
+- Test: `jean/src-tauri/tests/path_rewrite.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+use jean_ice::proxy::path_rewrite::rewrite_path;
+
+#[test]
+fn rewrites_amp_provider_paths() {
+    assert_eq!(rewrite_path("/provider/openai/chat"), "/api/provider/openai/chat");
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test path_rewrite`
+Expected: FAIL with missing rewrite module.
+
+**Step 3: Write minimal implementation**
+
+```rust
+pub fn rewrite_path(path: &str) -> String {
+    if path.starts_with("/provider/") { return format!("/api{}", path); }
+    path.to_string()
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test path_rewrite`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/proxy/path_rewrite.rs jean/src-tauri/src/proxy/server.rs jean/src-tauri/tests/path_rewrite.rs
+git commit -m "feat: add amp and v1 path compatibility rewrites"
+```
+
+---
+
+### Task 9: Implement Thinking and Reasoning Model Transforms
+
+**Files:**
+- Create: `jean/src-tauri/src/proxy/model_transform.rs`
+- Modify: `jean/src-tauri/src/proxy/server.rs`
+- Test: `jean/src-tauri/tests/model_transform.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+use jean_ice::proxy::model_transform::apply_transforms;
+
+#[test]
+fn adds_reasoning_effort_for_reasoning_suffix() {
+    let body = r#"{"model":"gpt-5.1-reasoning-high"}"#;
+    let out = apply_transforms(body).unwrap();
+    assert!(out.contains("\"reasoning\":{\"effort\":\"high\"}"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test model_transform`
+Expected: FAIL with missing transform module.
+
+**Step 3: Write minimal implementation**
+
+```rust
+pub struct TransformResult { pub body: String, pub thinking_enabled: bool }
+
+pub fn apply_transforms(body: &str) -> anyhow::Result<TransformResult> {
+    // 1) claude/gemini-claude -thinking-* => inject thinking + token headroom
+    // 2) non-claude -reasoning-* => inject reasoning.effort
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test model_transform`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/proxy/model_transform.rs jean/src-tauri/src/proxy/server.rs jean/src-tauri/tests/model_transform.rs
+git commit -m "feat: add thinking and reasoning compatibility transforms"
+```
+
+---
+
+### Task 10: Implement Qualified Model IDs and Provider-Pinned Routing
+
+**Files:**
+- Create: `jean/src-tauri/src/proxy/qualified_model.rs`
+- Modify: `jean/src-tauri/src/proxy/server.rs`
+- Test: `jean/src-tauri/tests/qualified_model_routing.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+use jean_ice::proxy::qualified_model::resolve_qualified_model;
+
+#[test]
+fn provider_prefixed_model_rewrites_path_and_model() {
+    let body = r#"{"model":"github-copilot/claude-sonnet-4-5"}"#;
+    let resolved = resolve_qualified_model("/v1/chat/completions", body).unwrap();
+    assert_eq!(resolved.forward_path, "/api/provider/github-copilot/v1/chat/completions");
+    assert!(resolved.forward_body.contains("\"model\":\"claude-sonnet-4-5\""));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test qualified_model_routing`
+Expected: FAIL with missing qualified model module.
+
+**Step 3: Write minimal implementation**
+
+```rust
+pub struct QualifiedRouting {
+    pub forward_path: String,
+    pub forward_body: String,
+    pub provider: Option<String>,
+    pub model_id: String,
+}
+
+pub fn resolve_qualified_model(path: &str, body: &str) -> anyhow::Result<QualifiedRouting> {
+    // if model contains provider/model_id:
+    // - set provider hint
+    // - rewrite model to model_id
+    // - forward to /api/provider/{provider}{path}
+    // else pass through unchanged
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test qualified_model_routing`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/proxy/qualified_model.rs jean/src-tauri/src/proxy/server.rs jean/src-tauri/tests/qualified_model_routing.rs
+git commit -m "feat: enforce provider-pinned routing for qualified model ids"
+```
+
+---
+
+### Task 11: Implement Model Groups (Manual Groups, Round-Robin, Failover, `/v1/models` Injection)
+
+**Files:**
+- Create: `jean/src-tauri/src/model_groups/group_store.rs`
+- Create: `jean/src-tauri/src/model_groups/router.rs`
+- Modify: `jean/src-tauri/src/proxy/server.rs`
+- Test: `jean/src-tauri/tests/model_group_router.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+use jean_ice::model_groups::router::{ModelGroup, ModelGroupRouter};
+
+#[test]
+fn round_robin_and_failover_behaves_as_expected() {
+    let mut router = ModelGroupRouter::default();
+    router.update(vec![ModelGroup::new("coding-fast", vec!["openai/gpt-5", "github-copilot/claude-sonnet-4-5"])]);
+
+    let first = router.resolve("coding-fast").unwrap();
+    let second = router.resolve("coding-fast").unwrap();
+    assert_ne!(first.real_model, second.real_model);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test model_group_router`
+Expected: FAIL with missing model_groups module.
+
+**Step 3: Write minimal implementation**
+
+```rust
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ModelGroup { pub id: Uuid, pub name: String, pub models: Vec<String>, pub enabled: bool }
+
+pub struct ModelGroupRouter { groups: Vec<ModelGroup>, counters: HashMap<Uuid, usize> }
+impl ModelGroupRouter {
+    pub fn resolve(&mut self, name: &str) -> Option<ResolvedGroupModel> { /* round-robin */ }
+    pub fn failover_next(&self, group_id: Uuid, tried: &HashSet<String>) -> Option<String> { /* retry candidate */ }
+    pub fn inject_models_response(&self, data: serde_json::Value) -> serde_json::Value { /* add virtual models */ }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test model_group_router`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/model_groups/group_store.rs jean/src-tauri/src/model_groups/router.rs jean/src-tauri/src/proxy/server.rs jean/src-tauri/tests/model_group_router.rs
+git commit -m "feat: add model groups with rr failover and models injection"
+```
+
+---
+
+### Task 12: Implement Diagnostics Usage Tracking and Next-Account Rotation
+
+**Files:**
+- Create: `jean/src-tauri/src/proxy/usage_stats.rs`
+- Modify: `jean/src-tauri/src/proxy/diagnostics.rs`
+- Test: `jean/src-tauri/tests/usage_rotation.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+use jean_ice::proxy::usage_stats::UsageStats;
+
+#[test]
+fn computes_next_account_rotation_from_provider_counts() {
+    let mut stats = UsageStats::default();
+    stats.bump_provider("claude");
+    let next = stats.next_account_index("claude", 3);
+    assert_eq!(next, 1);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test usage_rotation`
+Expected: FAIL with missing usage stats module.
+
+**Step 3: Write minimal implementation**
+
+```rust
+#[derive(Default)]
+pub struct UsageStats {
+    pub total_requests: u64,
+    pub endpoint_counts: HashMap<String, u64>,
+    pub provider_counts: HashMap<String, u64>,
+    pub model_counts: HashMap<String, u64>,
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test usage_rotation`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/proxy/usage_stats.rs jean/src-tauri/src/proxy/diagnostics.rs jean/src-tauri/tests/usage_rotation.rs
+git commit -m "feat: add diagnostics usage counters and rotation tracking"
+```
+
+---
+
+### Task 13: Implement Claude/Codex Usage Pollers + Auto-disable/Restore
+
+**Files:**
+- Create: `jean/src-tauri/src/usage/claude_usage.rs`
+- Create: `jean/src-tauri/src/usage/codex_usage.rs`
+- Create: `jean/src-tauri/src/usage/auto_disable.rs`
+- Test: `jean/src-tauri/tests/provider_usage_polling.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn marks_account_auto_disabled_when_remaining_is_zero() {
+    let result = jean_ice::usage::auto_disable::should_auto_disable(0);
+    assert!(result);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test provider_usage_polling`
+Expected: FAIL with missing usage modules.
+
+**Step 3: Write minimal implementation**
+
+```rust
+pub fn should_auto_disable(primary_remaining_percent: i32) -> bool {
+    primary_remaining_percent <= 0
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test provider_usage_polling`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/usage/claude_usage.rs jean/src-tauri/src/usage/codex_usage.rs jean/src-tauri/src/usage/auto_disable.rs jean/src-tauri/tests/provider_usage_polling.rs
+git commit -m "feat: add provider usage polling and auto-disable rules"
+```
+
+---
+
+### Task 14: Expose Tauri Commands for UI Integration
+
+**Files:**
+- Create: `jean/src-tauri/src/commands/proxy.rs`
+- Create: `jean/src-tauri/src/commands/accounts.rs`
+- Create: `jean/src-tauri/src/commands/model_groups.rs`
+- Modify: `jean/src-tauri/src/main.rs`
+- Test: `jean/src-tauri/tests/commands_smoke.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn toggle_proxy_command_updates_runtime_state() {
+    let state = jean_ice::app_state::AppState::new_for_test();
+    jean_ice::commands::proxy::set_proxy_enabled(tauri::State::from(&state), true).await.unwrap();
+    assert!(state.runtime.proxy_enabled());
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean/src-tauri && cargo test --test commands_smoke`
+Expected: FAIL with missing command handlers.
+
+**Step 3: Write minimal implementation**
+
+```rust
+#[tauri::command]
+pub async fn set_proxy_enabled(state: State<'_, AppState>, enabled: bool) -> Result<(), String> {
+    state.runtime.set_proxy_enabled(enabled).await.map_err(|e| e.to_string())
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd jean/src-tauri && cargo test --test commands_smoke`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/src/commands/proxy.rs jean/src-tauri/src/commands/accounts.rs jean/src-tauri/src/commands/model_groups.rs jean/src-tauri/src/main.rs jean/src-tauri/tests/commands_smoke.rs
+git commit -m "feat: expose tauri command surface for jean ui"
+```
+
+---
+
+### Task 15: Implement Frontend Parity Screens and Interaction Flows
+
+**Files:**
+- Create: `jean/src/features/settings/ProxySettingsPanel.tsx`
+- Create: `jean/src/features/accounts/ProviderAccountsPanel.tsx`
+- Create: `jean/src/features/model-groups/ModelGroupsPanel.tsx`
+- Create: `jean/src/features/usage/UsagePanel.tsx`
+- Create: `jean/src/lib/api/client.ts`
+- Test: `jean/src/features/settings/__tests__/ProxySettingsPanel.test.tsx`
+- Test: `jean/tests/e2e/parity-smoke.spec.ts`
+
+**Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { ProxySettingsPanel } from "../ProxySettingsPanel";
+
+test("renders proxy toggle and port field", () => {
+  render(<ProxySettingsPanel />);
+  expect(screen.getByLabelText(/Proxy enabled/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/Public proxy port/i)).toBeInTheDocument();
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd jean && pnpm vitest src/features/settings/__tests__/ProxySettingsPanel.test.tsx --run`
+Expected: FAIL with missing component.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+export function ProxySettingsPanel() {
+  return (
+    <section>
+      <label>Proxy enabled<input aria-label="Proxy enabled" type="checkbox" /></label>
+      <label>Public proxy port<input aria-label="Public proxy port" type="number" /></label>
+    </section>
+  );
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd jean && pnpm vitest src/features/settings/__tests__/ProxySettingsPanel.test.tsx --run`
+Expected: PASS.
+
+Run: `cd jean && pnpm playwright test tests/e2e/parity-smoke.spec.ts`
+Expected: PASS for startup, provider linking stub, and model group flow smoke checks.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src/features/settings/ProxySettingsPanel.tsx jean/src/features/accounts/ProviderAccountsPanel.tsx jean/src/features/model-groups/ModelGroupsPanel.tsx jean/src/features/usage/UsagePanel.tsx jean/src/lib/api/client.ts jean/src/features/settings/__tests__/ProxySettingsPanel.test.tsx jean/tests/e2e/parity-smoke.spec.ts
+git commit -m "feat: add jean parity ui panels and smoke tests"
+```
+
+---
+
+### Task 16: Cross-Platform Packaging, Autostart, and Release Verification
+
+**Files:**
+- Modify: `jean/src-tauri/tauri.conf.json`
+- Modify: `jean/src-tauri/Cargo.toml`
+- Create: `jean/scripts/verify-parity.sh`
+- Create: `jean/docs/compatibility/parity-checklist.md`
+- Create: `jean/docs/compatibility/provider-routing-matrix.md`
+
+**Step 1: Write the failing verification script check**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+curl -fsS http://127.0.0.1:8317/vibe/status >/dev/null
+curl -fsS http://127.0.0.1:8317/vibe/usage >/dev/null
+```
+
+**Step 2: Run verification to show missing behavior**
+
+Run: `cd jean && bash scripts/verify-parity.sh`
+Expected: FAIL before final wiring.
+
+**Step 3: Implement packaging + autostart configuration**
+
+```json
+{
+  "bundle": { "externalBin": ["binaries/cli-proxy-api-plus"] },
+  "plugins": { "autostart": { "enabled": true } }
+}
+```
+
+**Step 4: Run full verification**
+
+Run: `cd jean/src-tauri && cargo test`
+Expected: PASS.
+
+Run: `cd jean && pnpm test && bash scripts/verify-parity.sh`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add jean/src-tauri/tauri.conf.json jean/src-tauri/Cargo.toml jean/scripts/verify-parity.sh jean/docs/compatibility/parity-checklist.md jean/docs/compatibility/provider-routing-matrix.md
+git commit -m "chore: finalize cross-platform packaging and parity verification"
+```
+
+---
+
+## Final Release Gate (must be manually checked)
+
+1. Proxy toggle starts/stops edge + sidecar cleanly on macOS, Windows, Linux.
+2. Start-with-app works on all three platforms.
+3. Public proxy port override persists and binds correctly.
+4. All provider login flows complete and write valid auth files.
+5. Qualified model IDs pin provider routing correctly.
+6. Model groups rotate and fail over correctly on retryable statuses.
+7. `/v1/models` includes real + virtual models.
+8. Thinking/reasoning transforms are reflected in forwarded payloads.
+9. `/vibe/status`, `/vibe/usage`, `/vibe/usage/reset` match compatibility contract.
+10. Claude/Codex usage polling and auto-disable/restore behavior matches the expected UX.

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -45,13 +45,18 @@ cp -r VibeProxy.app "$DMG_STAGING/"
 ln -s /Applications "$DMG_STAGING/Applications"
 
 echo -e "${BLUE}Creating ${DMG_NAME}...${NC}"
-hdiutil create -volname "VibeProxy" -srcfolder "$DMG_STAGING" -ov -format UDZO -o "$PROJECT_DIR/$DMG_NAME"
+DMG_CREATED=false
+if hdiutil create -volname "VibeProxy" -srcfolder "$DMG_STAGING" -ov -format UDZO -o "$PROJECT_DIR/$DMG_NAME" 2>/dev/null; then
+    DMG_CREATED=true
+else
+    echo -e "${YELLOW}hdiutil failed (likely missing Full Disk Access) — skipping DMG${NC}"
+    echo -e "${YELLOW}Fix: System Settings → Privacy & Security → Full Disk Access → add your terminal${NC}"
+fi
 rm -rf "$DMG_STAGING"
 
 # --- Install locally ---
 echo -e "${BLUE}Installing to /Applications...${NC}"
 if [ -d "/Applications/VibeProxy.app" ]; then
-    # Kill running instance if any
     pkill -x CLIProxyMenuBar 2>/dev/null || true
     sleep 0.5
     rm -rf "/Applications/VibeProxy.app"
@@ -59,12 +64,14 @@ fi
 cp -r VibeProxy.app /Applications/
 
 # --- Summary ---
-CHECKSUM=$(shasum -a 256 "$DMG_NAME" | awk '{print $1}')
 echo ""
 echo -e "${GREEN}Done!${NC}"
 echo -e "  Version:  ${GREEN}v${VERSION}${NC}"
-echo -e "  DMG:      ${GREEN}${DMG_NAME}${NC} ($(du -h "$DMG_NAME" | awk '{print $1}'))"
-echo -e "  SHA-256:  ${CHECKSUM}"
+if [ "$DMG_CREATED" = true ]; then
+    CHECKSUM=$(shasum -a 256 "$DMG_NAME" | awk '{print $1}')
+    echo -e "  DMG:      ${GREEN}${DMG_NAME}${NC} ($(du -h "$DMG_NAME" | awk '{print $1}'))"
+    echo -e "  SHA-256:  ${CHECKSUM}"
+fi
 echo -e "  Installed to /Applications/VibeProxy.app"
 echo ""
 echo -e "${YELLOW}To launch:${NC} open /Applications/VibeProxy.app"

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Build VibeProxy.app, create a DMG, and install to /Applications
+# Usage: ./scripts/build-dmg.sh [version]
+# If no version given, auto-increments patch from latest git tag
+
+set -e
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_DIR"
+
+# --- Resolve version ---
+if [ -n "$1" ]; then
+    VERSION="$1"
+else
+    LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+    LATEST_TAG="${LATEST_TAG#v}"
+    IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST_TAG"
+    PATCH=$((PATCH + 1))
+    VERSION="${MAJOR}.${MINOR}.${PATCH}"
+fi
+echo -e "${BLUE}Building VibeProxy v${VERSION}${NC}"
+
+# --- Build app ---
+echo -e "${BLUE}Building .app bundle...${NC}"
+APP_VERSION="$VERSION" ./create-app-bundle.sh
+
+if [ ! -d "VibeProxy.app" ]; then
+    echo -e "${RED}Build failed — VibeProxy.app not found${NC}"
+    exit 1
+fi
+
+# --- Create DMG ---
+DMG_NAME="VibeProxy-${VERSION}.dmg"
+DMG_STAGING=$(mktemp -d)
+
+echo -e "${BLUE}Staging DMG contents...${NC}"
+cp -r VibeProxy.app "$DMG_STAGING/"
+ln -s /Applications "$DMG_STAGING/Applications"
+
+echo -e "${BLUE}Creating ${DMG_NAME}...${NC}"
+hdiutil create -volname "VibeProxy" -srcfolder "$DMG_STAGING" -ov -format UDZO -o "$PROJECT_DIR/$DMG_NAME"
+rm -rf "$DMG_STAGING"
+
+# --- Install locally ---
+echo -e "${BLUE}Installing to /Applications...${NC}"
+if [ -d "/Applications/VibeProxy.app" ]; then
+    # Kill running instance if any
+    pkill -x CLIProxyMenuBar 2>/dev/null || true
+    sleep 0.5
+    rm -rf "/Applications/VibeProxy.app"
+fi
+cp -r VibeProxy.app /Applications/
+
+# --- Summary ---
+CHECKSUM=$(shasum -a 256 "$DMG_NAME" | awk '{print $1}')
+echo ""
+echo -e "${GREEN}Done!${NC}"
+echo -e "  Version:  ${GREEN}v${VERSION}${NC}"
+echo -e "  DMG:      ${GREEN}${DMG_NAME}${NC} ($(du -h "$DMG_NAME" | awk '{print $1}'))"
+echo -e "  SHA-256:  ${CHECKSUM}"
+echo -e "  Installed to /Applications/VibeProxy.app"
+echo ""
+echo -e "${YELLOW}To launch:${NC} open /Applications/VibeProxy.app"

--- a/src/Sources/AppDelegate.swift
+++ b/src/Sources/AppDelegate.swift
@@ -4,17 +4,22 @@ import WebKit
 import UserNotifications
 import Sparkle
 
+@MainActor
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNotificationCenterDelegate {
     var statusItem: NSStatusItem!
     var menu: NSMenu!
     weak var settingsWindow: NSWindow?
     var serverManager: ServerManager!
     var thinkingProxy: ThinkingProxy!
+    let authManager = AuthManager()
+    let codexUsageManager = CodexUsageManager()
+    let claudeUsageManager = ClaudeUsageManager()
     private let notificationCenter = UNUserNotificationCenter.current()
     private var notificationPermissionGranted = false
     private let updaterController: SPUStandardUpdaterController
     private var authFileMonitor: DispatchSourceFileSystemObject?
     private var pendingAuthRefresh: DispatchWorkItem?
+    private var usageItemsController: MenuBarUsageItemsController?
     
     override init() {
         self.updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
@@ -24,24 +29,40 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Setup standard Edit menu for keyboard shortcuts (Cmd+C/V/X/A)
         setupMainMenu()
-        
-        // Setup menu bar
-        setupMenuBar()
 
-        // Initialize managers
+        // Initialize managers early so menu bar can reference thinkingProxy
         serverManager = ServerManager()
         thinkingProxy = ThinkingProxy()
+
+        // Setup menu bar (needs thinkingProxy)
+        setupMenuBar()
 
         // Sync Vercel AI Gateway config from ServerManager to ThinkingProxy
         syncVercelConfig()
         serverManager.onVercelConfigChanged = { [weak self] in
             self?.syncVercelConfig()
         }
-        
+
+        // Sync Model Groups from ServerManager to ThinkingProxy
+        syncModelGroups()
+        serverManager.onModelGroupsChanged = { [weak self] in
+            self?.syncModelGroups()
+        }
+
         // Warm commonly used icons to avoid first-use disk hits
         preloadIcons()
         
         configureNotifications()
+
+        // Start auth scanning and usage polling
+        authManager.checkAuthStatus()
+        startUsagePolling()
+
+        // Monitor auth directory for account changes
+        NotificationCenter.default.addObserver(forName: .authDirectoryChanged, object: nil, queue: .main) { [weak self] _ in
+            self?.authManager.checkAuthStatus()
+            self?.startUsagePolling()
+        }
 
         // Start server automatically
         startServer()
@@ -126,6 +147,46 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
         NSApplication.shared.mainMenu = mainMenu
     }
     
+    private func startUsagePolling() {
+        codexUsageManager.startPolling(accounts: authManager.accounts(for: .codex))
+        claudeUsageManager.startPolling(accounts: authManager.accounts(for: .claude))
+    }
+
+    /// Check usage data and auto-disable accounts at 0%, auto-restore recovered ones.
+    /// Called from MenuBarUsageItemsController's 3s timer via a callback.
+    func checkAutoDisableAccounts() {
+        // Auto-disable active accounts with 0% remaining
+        for account in authManager.accounts(for: .claude).filter({ !$0.isExpired }) {
+            if let usage = claudeUsageManager.usage(for: account.id),
+               case .loaded = usage.status,
+               let remaining = usage.primaryRemainingPercent, remaining <= 0 {
+                _ = authManager.autoDisableAccount(account)
+            }
+        }
+        for account in authManager.accounts(for: .codex).filter({ !$0.isExpired }) {
+            if let usage = codexUsageManager.usage(for: account.id),
+               case .loaded = usage.status,
+               let remaining = usage.primaryRemainingPercent, remaining <= 0 {
+                _ = authManager.autoDisableAccount(account)
+            }
+        }
+
+        // Auto-restore accounts whose usage has recovered
+        // We need to poll usage for auto-disabled accounts too
+        for account in authManager.autoDisabledAccounts {
+            let usage: ProviderUsageData?
+            switch account.type {
+            case .claude: usage = claudeUsageManager.usage(for: account.id)
+            case .codex: usage = codexUsageManager.usage(for: account.id)
+            default: usage = nil
+            }
+            if let usage = usage, case .loaded = usage.status,
+               let remaining = usage.primaryRemainingPercent, remaining > 0 {
+                _ = authManager.autoRestoreAccount(account)
+            }
+        }
+    }
+
     func setupMenuBar() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
 
@@ -145,6 +206,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
         // Server Status
         menu.addItem(NSMenuItem(title: "Server: Stopped", action: nil, keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
+
+        // Usage items (plain disabled NSMenuItems, inserted after the separator)
+        // Controller will manage its own items at this index
+        let usageInsertIndex = menu.numberOfItems
+        usageItemsController = MenuBarUsageItemsController(
+            menu: menu,
+            insertionIndex: usageInsertIndex,
+            authManager: authManager,
+            codexUsageManager: codexUsageManager,
+            claudeUsageManager: claudeUsageManager,
+            thinkingProxy: thinkingProxy
+        )
+        usageItemsController?.onRefresh = { [weak self] in
+            self?.checkAutoDisableAccounts()
+        }
 
         // Main Actions
         menu.addItem(NSMenuItem(title: "Open Settings", action: #selector(openSettings), keyEquivalent: "s"))
@@ -206,7 +282,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
         window.delegate = self
         window.isReleasedWhenClosed = false
 
-        let contentView = SettingsView(serverManager: serverManager)
+        let contentView = SettingsView(
+            serverManager: serverManager,
+            authManager: authManager,
+            codexUsageManager: codexUsageManager,
+            claudeUsageManager: claudeUsageManager
+        )
         window.contentView = NSHostingView(rootView: contentView)
 
         settingsWindow = window
@@ -434,6 +515,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
             enabled: serverManager.vercelGatewayEnabled,
             apiKey: serverManager.vercelApiKey
         )
+    }
+
+    private func syncModelGroups() {
+        thinkingProxy.modelGroupRouter.updateGroups(serverManager.modelGroups)
     }
 
     // MARK: - UNUserNotificationCenterDelegate

--- a/src/Sources/AuthStatus.swift
+++ b/src/Sources/AuthStatus.swift
@@ -8,7 +8,7 @@ enum ServiceType: String, CaseIterable {
     case qwen
     case antigravity
     case zai
-    
+
     var displayName: String {
         switch self {
         case .claude: return "Claude Code"
@@ -30,7 +30,6 @@ struct AuthAccount: Identifiable, Equatable {
     let type: ServiceType
     let expired: Date?
     let filePath: URL
-    let isDisabled: Bool
     
     var isExpired: Bool {
         guard let expired = expired else { return false }
@@ -64,7 +63,11 @@ struct ServiceAccounts {
 
 class AuthManager: ObservableObject {
     @Published var serviceAccounts: [ServiceType: ServiceAccounts] = [:]
-    
+    /// Accounts manually disabled by the user (file moved to .disabled/)
+    @Published var manuallyDisabledAccounts: [AuthAccount] = []
+    /// Accounts auto-disabled due to 0% usage (file moved to .disabled/.auto/)
+    @Published var autoDisabledAccounts: [AuthAccount] = []
+
     private static let dateFormatters: [ISO8601DateFormatter] = {
         let withFractional = ISO8601DateFormatter()
         withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -72,83 +75,147 @@ class AuthManager: ObservableObject {
         standard.formatOptions = [.withInternetDateTime]
         return [withFractional, standard]
     }()
-    
+
+    static let authDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".cli-proxy-api")
+    private static let disabledDir = authDir.appendingPathComponent(".disabled")
+    private static let autoDisabledDir = disabledDir.appendingPathComponent(".auto")
+
     init() {
-        // Initialize empty accounts for all service types
         for type in ServiceType.allCases {
             serviceAccounts[type] = ServiceAccounts(type: type)
         }
+        ensureDisabledDirs()
     }
-    
+
     func accounts(for type: ServiceType) -> [AuthAccount] {
         serviceAccounts[type]?.accounts ?? []
     }
-    
+
     func hasAccounts(for type: ServiceType) -> Bool {
         serviceAccounts[type]?.hasAccounts ?? false
     }
-    
+
+    /// Check if an account is manually disabled
+    func isManuallyDisabled(_ account: AuthAccount) -> Bool {
+        manuallyDisabledAccounts.contains { $0.id == account.id }
+    }
+
+    /// Check if an account is auto-disabled (depleted)
+    func isAutoDisabled(_ account: AuthAccount) -> Bool {
+        autoDisabledAccounts.contains { $0.id == account.id }
+    }
+
+    /// Manually disable an account — moves file to .disabled/
+    func disableAccount(_ account: AuthAccount) -> Bool {
+        let dest = Self.disabledDir.appendingPathComponent(account.id)
+        do {
+            try FileManager.default.moveItem(at: account.filePath, to: dest)
+            NSLog("[AuthStatus] Disabled account: %@ → .disabled/", account.displayName)
+            checkAuthStatus()
+            return true
+        } catch {
+            NSLog("[AuthStatus] Failed to disable account %@: %@", account.displayName, error.localizedDescription)
+            return false
+        }
+    }
+
+    /// Re-enable a manually disabled account — moves file back
+    func enableAccount(_ account: AuthAccount) -> Bool {
+        let source = Self.disabledDir.appendingPathComponent(account.id)
+        let dest = Self.authDir.appendingPathComponent(account.id)
+        do {
+            try FileManager.default.moveItem(at: source, to: dest)
+            NSLog("[AuthStatus] Re-enabled account: %@ → active", account.displayName)
+            checkAuthStatus()
+            return true
+        } catch {
+            NSLog("[AuthStatus] Failed to re-enable account %@: %@", account.displayName, error.localizedDescription)
+            return false
+        }
+    }
+
+    /// Auto-disable a depleted account (0% usage) — moves to .disabled/.auto/
+    func autoDisableAccount(_ account: AuthAccount) -> Bool {
+        // Don't auto-disable if already manually disabled
+        guard !isManuallyDisabled(account) else { return false }
+        let dest = Self.autoDisabledDir.appendingPathComponent(account.id)
+        do {
+            try FileManager.default.moveItem(at: account.filePath, to: dest)
+            NSLog("[AuthStatus] Auto-disabled depleted account: %@", account.displayName)
+            checkAuthStatus()
+            return true
+        } catch {
+            NSLog("[AuthStatus] Failed to auto-disable account %@: %@", account.displayName, error.localizedDescription)
+            return false
+        }
+    }
+
+    /// Restore an auto-disabled account when usage recovers
+    func autoRestoreAccount(_ account: AuthAccount) -> Bool {
+        let source = Self.autoDisabledDir.appendingPathComponent(account.id)
+        let dest = Self.authDir.appendingPathComponent(account.id)
+        do {
+            try FileManager.default.moveItem(at: source, to: dest)
+            NSLog("[AuthStatus] Auto-restored account: %@ (usage recovered)", account.displayName)
+            checkAuthStatus()
+            return true
+        } catch {
+            NSLog("[AuthStatus] Failed to auto-restore account %@: %@", account.displayName, error.localizedDescription)
+            return false
+        }
+    }
+
     func checkAuthStatus() {
-        let authDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".cli-proxy-api")
-        
-        // Build new accounts dictionary
+        let authDir = Self.authDir
+
         var newAccounts: [ServiceType: [AuthAccount]] = [:]
         for type in ServiceType.allCases {
             newAccounts[type] = []
         }
-        
+
+        var newManuallyDisabled: [AuthAccount] = []
+        var newAutoDisabled: [AuthAccount] = []
+
         do {
+            // Scan active accounts
             let files = try FileManager.default.contentsOfDirectory(at: authDir, includingPropertiesForKeys: nil)
             NSLog("[AuthStatus] Scanning %d files in auth directory", files.count)
-            
+
             for file in files where file.pathExtension == "json" {
-                NSLog("[AuthStatus] Checking file: %@", file.lastPathComponent)
-                guard let data = try? Data(contentsOf: file),
-                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                      let type = json["type"] as? String,
-                      let serviceType = ServiceType(rawValue: type.lowercased()) else {
-                    continue
-                }
-                
-                NSLog("[AuthStatus] Found type '%@' in %@", type, file.lastPathComponent)
-                
-                let email = json["email"] as? String
-                let login = json["login"] as? String
-                var expiredDate: Date?
-                
-                if let expiredStr = json["expired"] as? String {
-                    for formatter in Self.dateFormatters {
-                        if let date = formatter.date(from: expiredStr) {
-                            expiredDate = date
-                            break
-                        }
+                guard let account = parseAccountFile(file) else { continue }
+                newAccounts[account.type]?.append(account)
+                NSLog("[AuthStatus] Found %@ auth: %@", account.type.displayName, account.displayName)
+            }
+
+            // Scan manually disabled accounts
+            if let disabledFiles = try? FileManager.default.contentsOfDirectory(at: Self.disabledDir, includingPropertiesForKeys: nil) {
+                for file in disabledFiles where file.pathExtension == "json" {
+                    if let account = parseAccountFile(file) {
+                        newManuallyDisabled.append(account)
+                        NSLog("[AuthStatus] Found manually disabled: %@", account.displayName)
                     }
                 }
-                
-                let isDisabled = json["disabled"] as? Bool ?? false
-                
-                let account = AuthAccount(
-                    id: file.lastPathComponent,
-                    email: email,
-                    login: login,
-                    type: serviceType,
-                    expired: expiredDate,
-                    filePath: file,
-                    isDisabled: isDisabled
-                )
-                
-                newAccounts[serviceType]?.append(account)
-                NSLog("[AuthStatus] Found %@ auth: %@", serviceType.displayName, account.displayName)
             }
-            
-            // Update on main thread
+
+            // Scan auto-disabled accounts
+            if let autoFiles = try? FileManager.default.contentsOfDirectory(at: Self.autoDisabledDir, includingPropertiesForKeys: nil) {
+                for file in autoFiles where file.pathExtension == "json" {
+                    if let account = parseAccountFile(file) {
+                        newAutoDisabled.append(account)
+                        NSLog("[AuthStatus] Found auto-disabled: %@", account.displayName)
+                    }
+                }
+            }
+
             DispatchQueue.main.async {
                 for type in ServiceType.allCases {
                     self.serviceAccounts[type] = ServiceAccounts(
                         type: type,
-                        accounts: newAccounts[type] ?? []
+                        accounts: (newAccounts[type] ?? []).sorted { $0.id < $1.id }
                     )
                 }
+                self.manuallyDisabledAccounts = newManuallyDisabled.sorted { $0.id < $1.id }
+                self.autoDisabledAccounts = newAutoDisabled.sorted { $0.id < $1.id }
             }
         } catch {
             NSLog("[AuthStatus] Error checking auth status: %@", error.localizedDescription)
@@ -156,49 +223,65 @@ class AuthManager: ObservableObject {
                 for type in ServiceType.allCases {
                     self.serviceAccounts[type] = ServiceAccounts(type: type)
                 }
+                self.manuallyDisabledAccounts = []
+                self.autoDisabledAccounts = []
             }
         }
     }
-    
-    /// Toggle the disabled state of a specific account's auth file
-    func toggleAccountDisabled(_ account: AuthAccount) -> Bool {
-        do {
-            let data = try Data(contentsOf: account.filePath)
-            guard var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                NSLog("[AuthStatus] Failed to parse auth file as JSON: %@", account.filePath.path)
-                return false
-            }
-            let currentlyDisabled = json["disabled"] as? Bool ?? false
-            if !currentlyDisabled {
-                let enabledCount = serviceAccounts[account.type]?.accounts.filter { !$0.isDisabled }.count ?? 0
-                guard enabledCount > 1 else {
-                    NSLog("[AuthStatus] Refusing to disable last enabled account for %@", account.type.rawValue)
-                    return false
-                }
-            }
-            json["disabled"] = !currentlyDisabled
-            let updatedData = try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
-            try updatedData.write(to: account.filePath, options: .atomic)
-            NSLog("[AuthStatus] Toggled disabled=%d for: %@", !currentlyDisabled, account.filePath.path)
-            checkAuthStatus()
-            return true
-        } catch {
-            NSLog("[AuthStatus] Failed to toggle disabled state: %@", error.localizedDescription)
-            return false
-        }
-    }
-    
+
+
     /// Delete a specific account's auth file
     func deleteAccount(_ account: AuthAccount) -> Bool {
         do {
             try FileManager.default.removeItem(at: account.filePath)
             NSLog("[AuthStatus] Deleted auth file: %@", account.filePath.path)
-            // Refresh status
             checkAuthStatus()
             return true
         } catch {
             NSLog("[AuthStatus] Failed to delete auth file: %@", error.localizedDescription)
             return false
         }
+    }
+
+    // MARK: - Private
+
+    private func ensureDisabledDirs() {
+        let fm = FileManager.default
+        for dir in [Self.disabledDir, Self.autoDisabledDir] {
+            if !fm.fileExists(atPath: dir.path) {
+                try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+            }
+        }
+    }
+
+    private func parseAccountFile(_ file: URL) -> AuthAccount? {
+        guard let data = try? Data(contentsOf: file),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = json["type"] as? String,
+              let serviceType = ServiceType(rawValue: type.lowercased()) else {
+            return nil
+        }
+
+        let email = json["email"] as? String
+        let login = json["login"] as? String
+        var expiredDate: Date?
+
+        if let expiredStr = json["expired"] as? String {
+            for formatter in Self.dateFormatters {
+                if let date = formatter.date(from: expiredStr) {
+                    expiredDate = date
+                    break
+                }
+            }
+        }
+
+        return AuthAccount(
+            id: file.lastPathComponent,
+            email: email,
+            login: login,
+            type: serviceType,
+            expired: expiredDate,
+            filePath: file
+        )
     }
 }

--- a/src/Sources/ClaudeUsageManager.swift
+++ b/src/Sources/ClaudeUsageManager.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+// MARK: - Claude API Response Model
+
+private struct ClaudeUsageResponse: Decodable {
+    let fiveHour: WindowData?
+    let sevenDay: WindowData?
+    let sevenDaySonnet: WindowData?
+    let extraUsage: ExtraUsage?
+
+    enum CodingKeys: String, CodingKey {
+        case fiveHour = "five_hour"
+        case sevenDay = "seven_day"
+        case sevenDaySonnet = "seven_day_sonnet"
+        case extraUsage = "extra_usage"
+    }
+
+    struct WindowData: Decodable {
+        let utilization: Double?
+        let resetsAt: String? // ISO8601 timestamp
+
+        enum CodingKeys: String, CodingKey {
+            case utilization
+            case resetsAt = "resets_at"
+        }
+    }
+
+    struct ExtraUsage: Decodable {
+        let isEnabled: Bool?
+        let usedCredits: Double?
+        let monthlyLimit: Double?
+
+        enum CodingKeys: String, CodingKey {
+            case isEnabled = "is_enabled"
+            case usedCredits = "used_credits"
+            case monthlyLimit = "monthly_limit"
+        }
+    }
+}
+
+// MARK: - Manager
+
+@MainActor
+final class ClaudeUsageManager: ObservableObject {
+    @Published private(set) var usageByAccount: [String: ProviderUsageData] = [:]
+
+    private var pollTimer: Timer?
+    private let session: URLSession
+    private static let pollInterval: TimeInterval = 300 // 5 min
+    private static let usageURL = URL(string: "https://api.anthropic.com/api/oauth/usage")!
+
+    init() {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 15
+        config.timeoutIntervalForResource = 30
+        self.session = URLSession(configuration: config)
+    }
+
+    // MARK: - Public
+
+    func startPolling(accounts: [AuthAccount]) {
+        stopPolling()
+        let active = accounts.filter { $0.type == .claude && !$0.isExpired }
+        guard !active.isEmpty else {
+            usageByAccount = [:]
+            return
+        }
+        for a in active { usageByAccount[a.id] = .loading }
+        fetchAll(active)
+        pollTimer = Timer.scheduledTimer(withTimeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.fetchAll(active) }
+        }
+    }
+
+    func stopPolling() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+
+    func refreshNow(accounts: [AuthAccount]) {
+        let active = accounts.filter { $0.type == .claude && !$0.isExpired }
+        fetchAll(active)
+    }
+
+    func usage(for accountId: String) -> ProviderUsageData? {
+        usageByAccount[accountId]
+    }
+
+    // MARK: - Private
+
+    private func fetchAll(_ accounts: [AuthAccount]) {
+        for account in accounts {
+            Task { await fetchUsage(for: account) }
+        }
+    }
+
+    private func fetchUsage(for account: AuthAccount, attempt: Int = 1) async {
+        guard let accessToken = readAccessToken(from: account.filePath) else {
+            usageByAccount[account.id] = ProviderUsageData(
+                status: .error("No credentials"), primaryUsedPercent: nil, primaryResetSeconds: nil,
+                secondaryUsedPercent: nil, secondaryResetSeconds: nil,
+                creditBalance: nil, planType: nil, lastUpdated: Date()
+            )
+            return
+        }
+
+        var request = URLRequest(url: Self.usageURL)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+
+            if code == 200 {
+                let parsed = try JSONDecoder().decode(ClaudeUsageResponse.self, from: data)
+                usageByAccount[account.id] = mapResponse(parsed)
+            } else if code == 401 || code == 403 {
+                usageByAccount[account.id] = ProviderUsageData(
+                    status: .invalidCredentials, primaryUsedPercent: nil, primaryResetSeconds: nil,
+                    secondaryUsedPercent: nil, secondaryResetSeconds: nil,
+                    creditBalance: nil, planType: nil, lastUpdated: Date()
+                )
+            } else if code >= 500 && attempt < 3 {
+                // Retry on server errors (Anthropic 500s are transient)
+                NSLog("[ClaudeUsage] HTTP %d for %@, retrying (%d/3)", code, account.displayName, attempt)
+                try? await Task.sleep(nanoseconds: UInt64(attempt) * 2_000_000_000)
+                await fetchUsage(for: account, attempt: attempt + 1)
+            } else {
+                NSLog("[ClaudeUsage] HTTP %d for %@", code, account.displayName)
+                usageByAccount[account.id] = ProviderUsageData(
+                    status: .error("HTTP \(code)"), primaryUsedPercent: nil, primaryResetSeconds: nil,
+                    secondaryUsedPercent: nil, secondaryResetSeconds: nil,
+                    creditBalance: nil, planType: nil, lastUpdated: Date()
+                )
+            }
+        } catch let decodingError as DecodingError {
+            NSLog("[ClaudeUsage] Decode error for %@: %@", account.displayName, String(describing: decodingError))
+            usageByAccount[account.id] = ProviderUsageData(
+                status: .error("Bad response"), primaryUsedPercent: nil, primaryResetSeconds: nil,
+                secondaryUsedPercent: nil, secondaryResetSeconds: nil,
+                creditBalance: nil, planType: nil, lastUpdated: Date()
+            )
+        } catch {
+            NSLog("[ClaudeUsage] Network error for %@: %@", account.displayName, error.localizedDescription)
+            usageByAccount[account.id] = ProviderUsageData(
+                status: .error("Network error"), primaryUsedPercent: nil, primaryResetSeconds: nil,
+                secondaryUsedPercent: nil, secondaryResetSeconds: nil,
+                creditBalance: nil, planType: nil, lastUpdated: Date()
+            )
+        }
+    }
+
+    private func mapResponse(_ r: ClaudeUsageResponse) -> ProviderUsageData {
+        ProviderUsageData(
+            status: .loaded,
+            primaryUsedPercent: r.fiveHour?.utilization,
+            primaryResetSeconds: secondsUntil(r.fiveHour?.resetsAt),
+            secondaryUsedPercent: r.sevenDay?.utilization,
+            secondaryResetSeconds: secondsUntil(r.sevenDay?.resetsAt),
+            creditBalance: r.extraUsage?.usedCredits,
+            planType: nil,
+            lastUpdated: Date()
+        )
+    }
+
+    /// Convert ISO8601 "resets_at" timestamp to seconds from now
+    private func secondsUntil(_ isoString: String?) -> Int? {
+        guard let str = isoString else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = formatter.date(from: str) else {
+            // Try without fractional seconds
+            let basic = ISO8601DateFormatter()
+            basic.formatOptions = [.withInternetDateTime]
+            guard let d = basic.date(from: str) else { return nil }
+            return max(0, Int(d.timeIntervalSinceNow))
+        }
+        return max(0, Int(date.timeIntervalSinceNow))
+    }
+
+    private func readAccessToken(from filePath: URL) -> String? {
+        guard let data = try? Data(contentsOf: filePath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accessToken = json["access_token"] as? String else {
+            return nil
+        }
+        return accessToken
+    }
+
+    deinit { pollTimer?.invalidate() }
+}

--- a/src/Sources/CodexUsageManager.swift
+++ b/src/Sources/CodexUsageManager.swift
@@ -1,0 +1,267 @@
+import Foundation
+
+// MARK: - API Response Models (dual decode: nested object OR array)
+
+struct CodexUsageResponse: Decodable {
+    let primaryUsedPercent: Double?
+    let primaryRemainingSeconds: Int?
+    let secondaryUsedPercent: Double?
+    let secondaryRemainingSeconds: Int?
+    let creditBalance: Double?
+    let planType: String?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: RootKeys.self)
+        planType = try? container.decode(String.self, forKey: .planType)
+
+        // Credits — balance can be String "0" or Double 0
+        let creditsContainer = try? container.nestedContainer(keyedBy: CreditsKeys.self, forKey: .credits)
+        if let balanceStr = try? creditsContainer?.decode(String.self, forKey: .balance) {
+            creditBalance = Double(balanceStr)
+        } else {
+            creditBalance = try? creditsContainer?.decode(Double.self, forKey: .balance)
+        }
+
+        // Try nested object first: { "rate_limit": { "primary_window": { ... } } }
+        if let rlContainer = try? container.nestedContainer(keyedBy: RateLimitKeys.self, forKey: .rateLimit) {
+            let primary = try? rlContainer.nestedContainer(keyedBy: WindowKeys.self, forKey: .primaryWindow)
+            primaryUsedPercent = try? primary?.decode(Double.self, forKey: .usedPercent)
+            primaryRemainingSeconds = try? primary?.decode(Int.self, forKey: .resetAfterSeconds)
+            let secondary = try? rlContainer.nestedContainer(keyedBy: WindowKeys.self, forKey: .secondaryWindow)
+            secondaryUsedPercent = try? secondary?.decode(Double.self, forKey: .usedPercent)
+            secondaryRemainingSeconds = try? secondary?.decode(Int.self, forKey: .resetAfterSeconds)
+        }
+        // Fallback: array format { "rate_limits": [ { "window_type": "primary", ... } ] }
+        else if let limits = try? container.decode([RateLimitEntry].self, forKey: .rateLimits) {
+            let primary = limits.first { $0.windowType == "primary" }
+            primaryUsedPercent = primary?.usedPercent
+            primaryRemainingSeconds = primary?.resetAfterSeconds
+            let secondary = limits.first { $0.windowType == "secondary" }
+            secondaryUsedPercent = secondary?.usedPercent
+            secondaryRemainingSeconds = secondary?.resetAfterSeconds
+        } else {
+            primaryUsedPercent = nil
+            primaryRemainingSeconds = nil
+            secondaryUsedPercent = nil
+            secondaryRemainingSeconds = nil
+        }
+    }
+
+    private enum RootKeys: String, CodingKey {
+        case rateLimit = "rate_limit"
+        case rateLimits = "rate_limits"
+        case credits
+        case planType = "plan_type"
+    }
+    private enum RateLimitKeys: String, CodingKey {
+        case primaryWindow = "primary_window"
+        case secondaryWindow = "secondary_window"
+    }
+    private enum WindowKeys: String, CodingKey {
+        case usedPercent = "used_percent"
+        case resetAfterSeconds = "reset_after_seconds"
+    }
+    private enum CreditsKeys: String, CodingKey {
+        case balance
+    }
+    private struct RateLimitEntry: Decodable {
+        let windowType: String?
+        let usedPercent: Double?
+        let resetAfterSeconds: Int?
+        enum CodingKeys: String, CodingKey {
+            case windowType = "window_type"
+            case usedPercent = "used_percent"
+            case resetAfterSeconds = "reset_after_seconds"
+        }
+    }
+}
+
+// MARK: - UI-Facing Usage Data
+
+struct ProviderUsageData {
+    enum Status {
+        case loading
+        case loaded
+        case error(String)
+        case invalidCredentials
+    }
+
+    let status: Status
+    let primaryUsedPercent: Double?
+    let primaryResetSeconds: Int?
+    let secondaryUsedPercent: Double?
+    let secondaryResetSeconds: Int?
+    let creditBalance: Double?
+    let planType: String?
+    let lastUpdated: Date?
+
+    var primaryRemainingPercent: Int? {
+        guard let used = primaryUsedPercent else { return nil }
+        return max(0, Int(100 - used))
+    }
+
+    var secondaryRemainingPercent: Int? {
+        guard let used = secondaryUsedPercent else { return nil }
+        return max(0, Int(100 - used))
+    }
+
+    var primaryResetFormatted: String? {
+        formatSeconds(primaryResetSeconds)
+    }
+
+    var secondaryResetFormatted: String? {
+        formatSeconds(secondaryResetSeconds)
+    }
+
+    private func formatSeconds(_ seconds: Int?) -> String? {
+        guard let s = seconds, s > 0 else { return nil }
+        let h = s / 3600
+        let m = (s % 3600) / 60
+        if h >= 24 { return "\(h / 24)d \(h % 24)h" }
+        if h > 0 { return m > 0 ? "\(h)h \(m)m" : "\(h)h" }
+        return "\(m)m"
+    }
+
+    static let loading = ProviderUsageData(
+        status: .loading,
+        primaryUsedPercent: nil, primaryResetSeconds: nil,
+        secondaryUsedPercent: nil, secondaryResetSeconds: nil,
+        creditBalance: nil, planType: nil, lastUpdated: nil
+    )
+}
+
+// MARK: - Manager
+
+@MainActor
+final class CodexUsageManager: ObservableObject {
+    @Published private(set) var usageByAccount: [String: ProviderUsageData] = [:]
+
+    private var pollTimer: Timer?
+    private let session: URLSession
+    private static let pollInterval: TimeInterval = 300 // 5 min
+    private static let usageURL = URL(string: "https://chatgpt.com/backend-api/wham/usage")!
+
+    init() {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 15
+        config.timeoutIntervalForResource = 30
+        self.session = URLSession(configuration: config)
+    }
+
+    // MARK: - Public
+
+    func startPolling(accounts: [AuthAccount]) {
+        stopPolling()
+        let active = accounts.filter { $0.type == .codex && !$0.isExpired }
+        guard !active.isEmpty else {
+            usageByAccount = [:]
+            return
+        }
+        for a in active { usageByAccount[a.id] = .loading }
+        fetchAll(active)
+        pollTimer = Timer.scheduledTimer(withTimeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.fetchAll(active) }
+        }
+    }
+
+    func stopPolling() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+
+    func refreshNow(accounts: [AuthAccount]) {
+        let active = accounts.filter { $0.type == .codex && !$0.isExpired }
+        fetchAll(active)
+    }
+
+    func usage(for accountId: String) -> ProviderUsageData? {
+        usageByAccount[accountId]
+    }
+
+    // MARK: - Private
+
+    private func fetchAll(_ accounts: [AuthAccount]) {
+        for account in accounts {
+            Task { await fetchUsage(for: account) }
+        }
+    }
+
+    private func fetchUsage(for account: AuthAccount) async {
+        guard let creds = readCredentials(from: account.filePath) else {
+            usageByAccount[account.id] = ProviderUsageData(
+                status: .error("No credentials"), primaryUsedPercent: nil, primaryResetSeconds: nil,
+                secondaryUsedPercent: nil, secondaryResetSeconds: nil,
+                creditBalance: nil, planType: nil, lastUpdated: Date()
+            )
+            return
+        }
+
+        var request = URLRequest(url: Self.usageURL)
+        request.setValue("Bearer \(creds.accessToken)", forHTTPHeaderField: "Authorization")
+        if let accountId = creds.accountId {
+            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+
+            if code == 200 {
+                let parsed = try JSONDecoder().decode(CodexUsageResponse.self, from: data)
+                usageByAccount[account.id] = ProviderUsageData(
+                    status: .loaded,
+                    primaryUsedPercent: parsed.primaryUsedPercent,
+                    primaryResetSeconds: parsed.primaryRemainingSeconds,
+                    secondaryUsedPercent: parsed.secondaryUsedPercent,
+                    secondaryResetSeconds: parsed.secondaryRemainingSeconds,
+                    creditBalance: parsed.creditBalance,
+                    planType: parsed.planType,
+                    lastUpdated: Date()
+                )
+            } else if code == 401 || code == 403 {
+                usageByAccount[account.id] = ProviderUsageData(
+                    status: .invalidCredentials, primaryUsedPercent: nil, primaryResetSeconds: nil,
+                    secondaryUsedPercent: nil, secondaryResetSeconds: nil,
+                    creditBalance: nil, planType: nil, lastUpdated: Date()
+                )
+            } else {
+                NSLog("[CodexUsage] HTTP %d for %@", code, account.displayName)
+                usageByAccount[account.id] = ProviderUsageData(
+                    status: .error("HTTP \(code)"), primaryUsedPercent: nil, primaryResetSeconds: nil,
+                    secondaryUsedPercent: nil, secondaryResetSeconds: nil,
+                    creditBalance: nil, planType: nil, lastUpdated: Date()
+                )
+            }
+        } catch let decodingError as DecodingError {
+            NSLog("[CodexUsage] Decode error for %@: %@", account.displayName, String(describing: decodingError))
+            usageByAccount[account.id] = ProviderUsageData(
+                status: .error("Bad response"), primaryUsedPercent: nil, primaryResetSeconds: nil,
+                secondaryUsedPercent: nil, secondaryResetSeconds: nil,
+                creditBalance: nil, planType: nil, lastUpdated: Date()
+            )
+        } catch {
+            NSLog("[CodexUsage] Network error for %@: %@", account.displayName, error.localizedDescription)
+            usageByAccount[account.id] = ProviderUsageData(
+                status: .error("Network error"), primaryUsedPercent: nil, primaryResetSeconds: nil,
+                secondaryUsedPercent: nil, secondaryResetSeconds: nil,
+                creditBalance: nil, planType: nil, lastUpdated: Date()
+            )
+        }
+    }
+
+    private struct Credentials {
+        let accessToken: String
+        let accountId: String?
+    }
+
+    private func readCredentials(from filePath: URL) -> Credentials? {
+        guard let data = try? Data(contentsOf: filePath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accessToken = json["access_token"] as? String else {
+            return nil
+        }
+        return Credentials(accessToken: accessToken, accountId: json["account_id"] as? String)
+    }
+
+    deinit { pollTimer?.invalidate() }
+}

--- a/src/Sources/MenuBarUsageView.swift
+++ b/src/Sources/MenuBarUsageView.swift
@@ -1,0 +1,208 @@
+import Cocoa
+
+/// Builds and updates plain NSMenuItems for provider usage in the menu bar.
+/// Items are non-interactive, styled like "Server: Running (port 8317)".
+@MainActor
+final class MenuBarUsageItemsController {
+    private let authManager: AuthManager
+    private let codexUsageManager: CodexUsageManager
+    private let claudeUsageManager: ClaudeUsageManager
+    private let thinkingProxy: ThinkingProxy
+    private var refreshTimer: Timer?
+    /// Callback to trigger auto-disable check in AppDelegate
+    var onRefresh: (() -> Void)?
+
+    private(set) var menuItems: [NSMenuItem] = []
+    private weak var menu: NSMenu?
+    private let insertionIndex: Int
+
+    init(
+        menu: NSMenu,
+        insertionIndex: Int,
+        authManager: AuthManager,
+        codexUsageManager: CodexUsageManager,
+        claudeUsageManager: ClaudeUsageManager,
+        thinkingProxy: ThinkingProxy
+    ) {
+        self.menu = menu
+        self.insertionIndex = insertionIndex
+        self.authManager = authManager
+        self.codexUsageManager = codexUsageManager
+        self.claudeUsageManager = claudeUsageManager
+        self.thinkingProxy = thinkingProxy
+
+        // Refresh every 3s — cheap (just string updates) and always works
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.rebuildItems()
+                self?.onRefresh?()
+            }
+        }
+    }
+
+    deinit {
+        refreshTimer?.invalidate()
+    }
+
+    private func rebuildItems() {
+        guard let menu = menu else { return }
+
+        // Remove old items
+        for item in menuItems { menu.removeItem(item) }
+        menuItems.removeAll()
+
+        var idx = insertionIndex
+
+        // Claude accounts — kick off polling if accounts exist but no usage data yet
+        let claudeAccounts = authManager.accounts(for: .claude).filter { !$0.isExpired }
+        if !claudeAccounts.isEmpty && claudeUsageManager.usageByAccount.isEmpty {
+            claudeUsageManager.startPolling(accounts: claudeAccounts)
+        }
+        let providerCounts = thinkingProxy.providerRequestCounts()
+
+        let claudeDisabled = disabledAccounts(for: .claude)
+        if !claudeAccounts.isEmpty || !claudeDisabled.isEmpty {
+            let claudeTotal = providerCounts["claude"] ?? 0
+            let claudePerAccount = perAccountCounts(totalRequests: claudeTotal, accountCount: claudeAccounts.count)
+            let header = makeSectionHeader("Claude")
+            menu.insertItem(header, at: idx); menuItems.append(header); idx += 1
+            for (i, account) in claudeAccounts.enumerated() {
+                let usage = claudeUsageManager.usage(for: account.id)
+                let reqCount = claudeAccounts.count > 1 ? claudePerAccount[i] : nil
+                let item = makeDisabledItem(formatAccountLine(email: account.displayName, usage: usage, requestCount: reqCount))
+                menu.insertItem(item, at: idx); menuItems.append(item); idx += 1
+            }
+            // Show disabled/depleted accounts dimmed
+            for (account, reason) in claudeDisabled {
+                let item = makeDimmedItem("\(account.displayName)  (\(reason))")
+                menu.insertItem(item, at: idx); menuItems.append(item); idx += 1
+            }
+            appendRotationIndicator(accounts: claudeAccounts, requestCount: claudeTotal, menu: menu, idx: &idx)
+        }
+
+        // Codex accounts — kick off polling if accounts exist but no usage data yet
+        let codexAccounts = authManager.accounts(for: .codex).filter { !$0.isExpired }
+        if !codexAccounts.isEmpty && codexUsageManager.usageByAccount.isEmpty {
+            codexUsageManager.startPolling(accounts: codexAccounts)
+        }
+        let codexDisabled = disabledAccounts(for: .codex)
+        if !codexAccounts.isEmpty || !codexDisabled.isEmpty {
+            let codexTotal = providerCounts["codex"] ?? 0
+            let codexPerAccount = perAccountCounts(totalRequests: codexTotal, accountCount: codexAccounts.count)
+            let header = makeSectionHeader("Codex")
+            menu.insertItem(header, at: idx); menuItems.append(header); idx += 1
+            for (i, account) in codexAccounts.enumerated() {
+                let usage = codexUsageManager.usage(for: account.id)
+                let reqCount = codexAccounts.count > 1 ? codexPerAccount[i] : nil
+                let item = makeDisabledItem(formatAccountLine(email: account.displayName, usage: usage, requestCount: reqCount))
+                menu.insertItem(item, at: idx); menuItems.append(item); idx += 1
+            }
+            for (account, reason) in codexDisabled {
+                let item = makeDimmedItem("\(account.displayName)  (\(reason))")
+                menu.insertItem(item, at: idx); menuItems.append(item); idx += 1
+            }
+            appendRotationIndicator(accounts: codexAccounts, requestCount: codexTotal, menu: menu, idx: &idx)
+        }
+
+        // Separator after usage items (only if we added any)
+        if !menuItems.isEmpty {
+            let sep = NSMenuItem.separator()
+            menu.insertItem(sep, at: idx)
+            menuItems.append(sep)
+        }
+    }
+
+    /// Get disabled accounts for a provider with their reason
+    private func disabledAccounts(for type: ServiceType) -> [(AuthAccount, String)] {
+        var result: [(AuthAccount, String)] = []
+        for account in authManager.manuallyDisabledAccounts where account.type == type {
+            result.append((account, "disabled"))
+        }
+        for account in authManager.autoDisabledAccounts where account.type == type {
+            result.append((account, "no credits"))
+        }
+        return result.sorted { $0.0.id < $1.0.id }
+    }
+
+    private func formatAccountLine(email: String, usage: ProviderUsageData?, requestCount: Int?) -> String {
+        var parts: [String] = []
+
+        if let usage = usage {
+            switch usage.status {
+            case .loading:
+                parts.append("⏳")
+            case .invalidCredentials:
+                parts.append("⚠️ expired")
+            case .error:
+                parts.append("⚠️ error")
+            case .loaded:
+                if let remaining = usage.primaryRemainingPercent {
+                    if let reset = usage.primaryResetFormatted {
+                        parts.append("\(remaining)%, \(reset)")
+                    } else {
+                        parts.append("\(remaining)%")
+                    }
+                }
+            }
+        }
+
+        if let count = requestCount {
+            parts.append("\(count) req")
+        }
+
+        if parts.isEmpty { return email }
+        return "\(email)  (\(parts.joined(separator: ", ")))"
+    }
+
+    /// Compute estimated per-account request counts from round-robin total.
+    private func perAccountCounts(totalRequests: Int, accountCount: Int) -> [Int] {
+        guard accountCount > 0 else { return [] }
+        let base = totalRequests / accountCount
+        let remainder = totalRequests % accountCount
+        return (0..<accountCount).map { i in base + (i < remainder ? 1 : 0) }
+    }
+
+    private func makeSectionHeader(_ providerName: String) -> NSMenuItem {
+        let item = NSMenuItem(title: providerName, action: nil, keyEquivalent: "")
+        item.isEnabled = false
+        // Use labelColor — disabled items get dimmed by macOS; secondaryLabelColor becomes invisible
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: NSFont.smallSystemFontSize, weight: .semibold),
+            .foregroundColor: NSColor.labelColor
+        ]
+        item.attributedTitle = NSAttributedString(string: providerName.uppercased(), attributes: attrs)
+        return item
+    }
+
+    private func appendRotationIndicator(accounts: [AuthAccount], requestCount: Int, menu: NSMenu, idx: inout Int) {
+        guard accounts.count > 1 else { return }
+        let count = accounts.count
+        if requestCount > 0 {
+            let lastIdx = (requestCount - 1) % count
+            let nextIdx = requestCount % count
+            let text = "  \(accounts[lastIdx].displayName) \u{25B8} \(accounts[nextIdx].displayName)"
+            let item = makeDisabledItem(text)
+            menu.insertItem(item, at: idx); menuItems.append(item); idx += 1
+        } else {
+            let item = makeDisabledItem("  next \u{25B8} \(accounts[0].displayName)")
+            menu.insertItem(item, at: idx); menuItems.append(item); idx += 1
+        }
+    }
+
+    private func makeDisabledItem(_ title: String) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.isEnabled = false
+        return item
+    }
+
+    private func makeDimmedItem(_ title: String) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.isEnabled = false
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: NSFont.smallSystemFontSize),
+            .foregroundColor: NSColor.tertiaryLabelColor
+        ]
+        item.attributedTitle = NSAttributedString(string: "  \(title)", attributes: attrs)
+        return item
+    }
+}

--- a/src/Sources/ModelGroup.swift
+++ b/src/Sources/ModelGroup.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+struct ModelGroup: Codable, Identifiable, Equatable {
+    let id: UUID
+    var name: String
+    var models: [String]
+    var enabled: Bool
+
+    init(id: UUID = UUID(), name: String = "", models: [String] = [], enabled: Bool = true) {
+        self.id = id
+        self.name = name
+        self.models = models
+        self.enabled = enabled
+    }
+}
+
+class ModelGroupRouter {
+    private var groups: [ModelGroup] = []
+    private var counters: [UUID: Int] = [:]
+    private let lock = NSLock()
+
+    func updateGroups(_ newGroups: [ModelGroup]) {
+        lock.lock()
+        defer { lock.unlock() }
+        groups = newGroups.filter { $0.enabled && !$0.models.isEmpty }
+        let validIds = Set(groups.map(\.id))
+        counters = counters.filter { validIds.contains($0.key) }
+    }
+
+    func resolveModel(_ model: String) -> (groupId: UUID, realModel: String)? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let group = groups.first(where: { $0.name == model }) else { return nil }
+        let index = counters[group.id, default: 0] % group.models.count
+        counters[group.id] = (index + 1) % group.models.count
+        return (group.id, group.models[index])
+    }
+
+    func failoverModel(groupId: UUID, excluding tried: Set<String>) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let group = groups.first(where: { $0.id == groupId }) else { return nil }
+        return group.models.first { !tried.contains($0) }
+    }
+
+    func activeGroupNames() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return groups.map(\.name)
+    }
+}

--- a/src/Sources/ServerManager.swift
+++ b/src/Sources/ServerManager.swift
@@ -71,6 +71,17 @@ class ServerManager: ObservableObject {
     }
     var onVercelConfigChanged: (() -> Void)?
 
+    @Published var modelGroups: [ModelGroup] = [] {
+        didSet {
+            if let data = try? JSONEncoder().encode(modelGroups) {
+                UserDefaults.standard.set(data, forKey: "modelGroups")
+            }
+            onModelGroupsChanged?()
+        }
+    }
+
+    var onModelGroupsChanged: (() -> Void)?
+
     /// Helper class to capture output text across closures
     private class OutputCapture {
         var text = ""
@@ -104,6 +115,10 @@ class ServerManager: ObservableObject {
         }
         vercelGatewayEnabled = UserDefaults.standard.bool(forKey: "vercelGatewayEnabled")
         vercelApiKey = UserDefaults.standard.string(forKey: "vercelApiKey") ?? ""
+        if let data = UserDefaults.standard.data(forKey: "modelGroups"),
+           let saved = try? JSONDecoder().decode([ModelGroup].self, from: data) {
+            modelGroups = saved
+        }
     }
 
     /// Check if a provider is enabled (defaults to true if not set)

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -1,49 +1,61 @@
 import SwiftUI
 import ServiceManagement
 
-/// A single account row with disable toggle and remove button
+// MARK: - Models API Types
+
+fileprivate struct ModelInfo: Decodable, Identifiable {
+    let id: String
+    let owned_by: String
+}
+
+fileprivate struct ModelsResponse: Decodable {
+    let data: [ModelInfo]
+}
+
+/// A single account row with enable/disable toggle and remove button
 struct AccountRowView: View {
     let account: AuthAccount
     let removeColor: Color
-    let showDisableToggle: Bool
-    let isLastEnabled: Bool
-    let onToggleDisabled: () -> Void
+    let isDisabled: Bool
+    let disableReason: String?
     let onRemove: () -> Void
-    
+    let onToggleEnabled: (Bool) -> Void
+
+    init(account: AuthAccount, removeColor: Color, isDisabled: Bool = false, disableReason: String? = nil,
+         onRemove: @escaping () -> Void, onToggleEnabled: @escaping (Bool) -> Void = { _ in }) {
+        self.account = account
+        self.removeColor = removeColor
+        self.isDisabled = isDisabled
+        self.disableReason = disableReason
+        self.onRemove = onRemove
+        self.onToggleEnabled = onToggleEnabled
+    }
+
     var body: some View {
         HStack(spacing: 8) {
+            Toggle("", isOn: Binding(
+                get: { !isDisabled },
+                set: { onToggleEnabled($0) }
+            ))
+            .toggleStyle(.switch)
+            .controlSize(.mini)
+            .labelsHidden()
+
             Circle()
-                .fill(account.isDisabled ? Color.gray : (account.isExpired ? Color.orange : Color.green))
+                .fill(statusColor)
                 .frame(width: 6, height: 6)
             Text(account.displayName)
                 .font(.caption)
-                .foregroundColor(account.isDisabled ? .secondary.opacity(0.5) : (account.isExpired ? .orange : .secondary))
-                .strikethrough(account.isDisabled)
-            if account.isExpired && !account.isDisabled {
+                .foregroundColor(isDisabled ? .gray : (account.isExpired ? .orange : .secondary))
+            if account.isExpired {
                 Text("(expired)")
                     .font(.caption2)
                     .foregroundColor(.orange)
             }
-            if account.isDisabled {
-                Text("(disabled)")
+            if let reason = disableReason {
+                Text("(\(reason))")
                     .font(.caption2)
                     .foregroundColor(.secondary)
-            }
-            if showDisableToggle {
-                let canDisable = account.isDisabled || !isLastEnabled
-                Button(action: onToggleDisabled) {
-                    Text(account.isDisabled ? "Enable" : "Disable")
-                        .font(.caption)
-                        .foregroundColor(account.isDisabled ? .green : (canDisable ? .orange : .secondary.opacity(0.4)))
-                }
-                .buttonStyle(.plain)
-                .disabled(!canDisable)
-                .help(!canDisable ? "At least one account must remain enabled" : "")
-                .onHover { inside in
-                    if canDisable {
-                        if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
-                }
             }
             Button(action: onRemove) {
                 HStack(spacing: 2) {
@@ -60,6 +72,82 @@ struct AccountRowView: View {
             }
         }
         .padding(.leading, 28)
+        .opacity(isDisabled ? 0.5 : 1.0)
+    }
+
+    private var statusColor: Color {
+        if isDisabled { return .gray }
+        if account.isExpired { return .orange }
+        return .green
+    }
+}
+
+/// Provider usage pills shown per-account in expanded section
+struct ProviderUsageRow: View {
+    let usage: ProviderUsageData?
+
+    var body: some View {
+        HStack(spacing: 6) {
+            if let usage = usage {
+                switch usage.status {
+                case .loading:
+                    ProgressView()
+                        .controlSize(.mini)
+                    Text("Checking usage...")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                case .loaded:
+                    usagePills(usage)
+                case .invalidCredentials:
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.caption2)
+                        .foregroundColor(.red)
+                    Text("Invalid credentials")
+                        .font(.caption2)
+                        .foregroundColor(.red)
+                case .error(let msg):
+                    Image(systemName: "exclamationmark.circle")
+                        .font(.caption2)
+                        .foregroundColor(.orange)
+                    Text(msg)
+                        .font(.caption2)
+                        .foregroundColor(.orange)
+                }
+            }
+        }
+        .padding(.leading, 42)
+    }
+
+    @ViewBuilder
+    private func usagePills(_ usage: ProviderUsageData) -> some View {
+        if let remaining = usage.primaryRemainingPercent {
+            pillView(percent: remaining, label: "left", reset: usage.primaryResetFormatted, color: pillColor(remaining))
+        }
+        if let remaining = usage.secondaryRemainingPercent {
+            pillView(percent: remaining, label: "weekly", reset: usage.secondaryResetFormatted, color: pillColor(remaining))
+        }
+    }
+
+    private func pillView(percent: Int, label: String, reset: String?, color: Color) -> some View {
+        HStack(spacing: 2) {
+            Text("\(percent)% \(label)")
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+            if let reset = reset {
+                Text("(\(reset))")
+                    .font(.system(size: 9, design: .monospaced))
+            }
+        }
+        .padding(.horizontal, 5)
+        .padding(.vertical, 1)
+        .background(color.opacity(0.15))
+        .foregroundColor(color)
+        .cornerRadius(3)
+    }
+
+    private func pillColor(_ percent: Int) -> Color {
+        if percent > 50 { return .green }
+        if percent > 20 { return .orange }
+        return .red
     }
 }
 
@@ -110,25 +198,29 @@ struct VercelGatewayControls: View {
 }
 
 /// A row displaying a service with its connected accounts and add button
-struct ServiceRow<ExtraContent: View>: View {
+struct ServiceRow<ExtraContent: View, AccountContent: View>: View {
     let serviceType: ServiceType
     let iconName: String
     let accounts: [AuthAccount]
+    let disabledAccounts: [AuthAccount]
+    let autoDisabledAccounts: [AuthAccount]
     let isAuthenticating: Bool
     let helpText: String?
     let isEnabled: Bool
     let customTitle: String?
     let onConnect: () -> Void
     let onDisconnect: (AuthAccount) -> Void
-    let onToggleDisabled: (AuthAccount) -> Void
     let onToggleEnabled: (Bool) -> Void
+    let onToggleAccountEnabled: (AuthAccount, Bool) -> Void
     var onExpandChange: ((Bool) -> Void)? = nil
     @ViewBuilder var extraContent: () -> ExtraContent
+    @ViewBuilder var accountContent: (AuthAccount) -> AccountContent
 
     @State private var isExpanded = false
     @State private var accountToRemove: AuthAccount?
     @State private var showingRemoveConfirmation = false
 
+    private var allAccounts: [AuthAccount] { accounts + disabledAccounts + autoDisabledAccounts }
     private var activeCount: Int { accounts.filter { !$0.isExpired }.count }
     private var expiredCount: Int { accounts.filter { $0.isExpired }.count }
     private let removeColor = Color(red: 0xeb/255, green: 0x0f/255, blue: 0x0f/255)
@@ -175,15 +267,21 @@ struct ServiceRow<ExtraContent: View>: View {
             
             // Account display (only shown when enabled)
             if isEnabled {
-                let enabledCount = accounts.filter { !$0.isDisabled }.count
-                if !accounts.isEmpty {
+                if !allAccounts.isEmpty {
                     // Collapsible summary
                     HStack(spacing: 4) {
-                        Text("\(accounts.count) connected account\(accounts.count == 1 ? "" : "s")")
+                        let totalCount = allAccounts.count
+                        let disabledCount = disabledAccounts.count + autoDisabledAccounts.count
+                        Text("\(totalCount) account\(totalCount == 1 ? "" : "s")")
                             .font(.caption)
                             .foregroundColor(.green)
+                        if disabledCount > 0 {
+                            Text("• \(disabledCount) paused")
+                                .font(.caption)
+                                .foregroundColor(.orange)
+                        }
 
-                        if enabledCount > 1 {
+                        if activeCount > 1 {
                             Text("• Round-robin w/ auto-failover")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
@@ -204,13 +302,39 @@ struct ServiceRow<ExtraContent: View>: View {
                     // Expanded accounts list
                     if isExpanded {
                         VStack(alignment: .leading, spacing: 6) {
+                            // Active accounts
                             ForEach(accounts) { account in
-                                AccountRowView(account: account, removeColor: removeColor, showDisableToggle: accounts.count > 1, isLastEnabled: !account.isDisabled && enabledCount <= 1, onToggleDisabled: {
-                                    onToggleDisabled(account)
-                                }) {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    AccountRowView(account: account, removeColor: removeColor, onRemove: {
+                                        accountToRemove = account
+                                        showingRemoveConfirmation = true
+                                    }, onToggleEnabled: { enabled in
+                                        onToggleAccountEnabled(account, enabled)
+                                    })
+                                    accountContent(account)
+                                }
+                            }
+                            // Manually disabled accounts
+                            ForEach(disabledAccounts) { account in
+                                AccountRowView(account: account, removeColor: removeColor,
+                                               isDisabled: true, disableReason: "disabled",
+                                               onRemove: {
                                     accountToRemove = account
                                     showingRemoveConfirmation = true
-                                }
+                                }, onToggleEnabled: { enabled in
+                                    onToggleAccountEnabled(account, enabled)
+                                })
+                            }
+                            // Auto-disabled accounts (depleted)
+                            ForEach(autoDisabledAccounts) { account in
+                                AccountRowView(account: account, removeColor: removeColor,
+                                               isDisabled: true, disableReason: "no credits",
+                                               onRemove: {
+                                    accountToRemove = account
+                                    showingRemoveConfirmation = true
+                                }, onToggleEnabled: { enabled in
+                                    onToggleAccountEnabled(account, enabled)
+                                })
                             }
                             extraContent()
                         }
@@ -257,9 +381,273 @@ struct ServiceRow<ExtraContent: View>: View {
     }
 }
 
+// Default accountContent = EmptyView for call sites that don't need per-account content
+extension ServiceRow where AccountContent == EmptyView {
+    init(
+        serviceType: ServiceType, iconName: String, accounts: [AuthAccount],
+        disabledAccounts: [AuthAccount] = [], autoDisabledAccounts: [AuthAccount] = [],
+        isAuthenticating: Bool, helpText: String?, isEnabled: Bool, customTitle: String?,
+        onConnect: @escaping () -> Void, onDisconnect: @escaping (AuthAccount) -> Void,
+        onToggleEnabled: @escaping (Bool) -> Void,
+        onToggleAccountEnabled: @escaping (AuthAccount, Bool) -> Void = { _, _ in },
+        onExpandChange: ((Bool) -> Void)? = nil,
+        @ViewBuilder extraContent: @escaping () -> ExtraContent
+    ) {
+        self.serviceType = serviceType; self.iconName = iconName; self.accounts = accounts
+        self.disabledAccounts = disabledAccounts; self.autoDisabledAccounts = autoDisabledAccounts
+        self.isAuthenticating = isAuthenticating; self.helpText = helpText; self.isEnabled = isEnabled
+        self.customTitle = customTitle; self.onConnect = onConnect; self.onDisconnect = onDisconnect
+        self.onToggleEnabled = onToggleEnabled; self.onToggleAccountEnabled = onToggleAccountEnabled
+        self.onExpandChange = onExpandChange
+        self.extraContent = extraContent; self.accountContent = { _ in EmptyView() }
+    }
+}
+
+fileprivate struct ModelGroupRow: View {
+    @Binding var group: ModelGroup
+    let onDelete: () -> Void
+    let availableModels: [String: [ModelInfo]]
+    @State private var showingModelPicker = false
+
+    private static let providerColors: [String: Color] = [
+        "anthropic": .orange, "openai": .green, "github-copilot": .purple,
+        "google": .blue, "qwen": .cyan, "zai": .yellow,
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Top row: toggle + name field + delete
+            HStack(spacing: 8) {
+                Toggle("", isOn: $group.enabled)
+                    .toggleStyle(.switch)
+                    .controlSize(.mini)
+                    .labelsHidden()
+
+                TextField("Enter group name", text: $group.name)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+
+                Button(action: onDelete) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 14))
+                        .foregroundColor(.secondary.opacity(0.5))
+                }
+                .buttonStyle(.plain)
+                .help("Delete group")
+                .onHover { inside in
+                    if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                }
+            }
+
+            if group.enabled {
+                // Models list
+                VStack(alignment: .leading, spacing: 0) {
+                    if group.models.isEmpty {
+                        HStack {
+                            Text("No models added yet")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                            Spacer()
+                        }
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 8)
+                    } else {
+                        ForEach(group.models.indices, id: \.self) { index in
+                            HStack(spacing: 6) {
+                                // Provider pill
+                                let parts = splitQualified(group.models[index])
+                                if let provider = parts.provider {
+                                    Text(provider)
+                                        .font(.system(size: 9, weight: .medium))
+                                        .foregroundColor(Self.providerColors[provider] ?? .secondary)
+                                        .padding(.horizontal, 5)
+                                        .padding(.vertical, 2)
+                                        .background((Self.providerColors[provider] ?? .secondary).opacity(0.12))
+                                        .cornerRadius(4)
+                                }
+
+                                Text(parts.modelId)
+                                    .font(.system(size: 11, design: .monospaced))
+
+                                Spacer()
+
+                                Button(action: { group.models.remove(at: index) }) {
+                                    Image(systemName: "minus.circle.fill")
+                                        .font(.system(size: 12))
+                                        .foregroundColor(.secondary.opacity(0.4))
+                                }
+                                .buttonStyle(.plain)
+                                .onHover { inside in
+                                    if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                                }
+                            }
+                            .padding(.vertical, 4)
+                            .padding(.horizontal, 8)
+
+                            if index < group.models.count - 1 {
+                                Divider().padding(.leading, 8)
+                            }
+                        }
+                    }
+
+                    // Add model row
+                    Button(action: { showingModelPicker.toggle() }) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "plus")
+                                .font(.system(size: 10, weight: .semibold))
+                            Text("Add Model")
+                                .font(.system(size: 11, weight: .medium))
+                        }
+                        .foregroundColor(.accentColor)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 8)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { inside in
+                        if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                    }
+                    .popover(isPresented: $showingModelPicker, arrowEdge: .bottom) {
+                        ModelPickerPopover(
+                            availableModels: availableModels,
+                            alreadyAdded: Set(group.models),
+                            onSelect: { qualifiedName in
+                                group.models.append(qualifiedName)
+                                showingModelPicker = false
+                            }
+                        )
+                    }
+                }
+                .background(Color(nsColor: .controlBackgroundColor).opacity(0.3))
+                .cornerRadius(6)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color.secondary.opacity(0.15), lineWidth: 1)
+                )
+
+                if group.models.count > 1 {
+                    Text("Requests round-robin across models with auto-failover")
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func splitQualified(_ qualified: String) -> (provider: String?, modelId: String) {
+        guard let idx = qualified.firstIndex(of: "/") else { return (nil, qualified) }
+        return (String(qualified[..<idx]), String(qualified[qualified.index(after: idx)...]))
+    }
+}
+
+private struct ModelPickerPopover: View {
+    let availableModels: [String: [ModelInfo]]
+    let alreadyAdded: Set<String>
+    let onSelect: (String) -> Void
+    @State private var searchText = ""
+    @State private var hoveredModel: String?
+
+    private static let providerDisplayNames: [String: String] = [
+        "anthropic": "Anthropic", "openai": "OpenAI", "github-copilot": "GitHub Copilot",
+        "google": "Google", "qwen": "Qwen", "zai": "Z.AI",
+    ]
+
+    private var filteredModels: [(provider: String, models: [ModelInfo])] {
+        let search = searchText.lowercased()
+        return availableModels.keys.sorted().compactMap { provider in
+            let models = availableModels[provider]?.filter { model in
+                let qualifiedName = "\(provider)/\(model.id)"
+                if alreadyAdded.contains(qualifiedName) { return false }
+                if search.isEmpty { return true }
+                return model.id.lowercased().contains(search) || provider.lowercased().contains(search)
+            } ?? []
+            return models.isEmpty ? nil : (provider: provider, models: models)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                TextField("Search models...", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12))
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if filteredModels.isEmpty {
+                        Text("No matching models")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 20)
+                    } else {
+                        ForEach(filteredModels, id: \.provider) { group in
+                            HStack(spacing: 5) {
+                                Text(Self.providerDisplayNames[group.provider] ?? group.provider.capitalized)
+                                    .font(.system(size: 10, weight: .semibold))
+                                    .foregroundColor(.secondary)
+                                    .textCase(.uppercase)
+                                Spacer()
+                                Text("\(group.models.count)")
+                                    .font(.system(size: 9, weight: .medium, design: .monospaced))
+                                    .foregroundColor(.secondary)
+                            }
+                            .padding(.horizontal, 10)
+                            .padding(.top, 10)
+                            .padding(.bottom, 4)
+
+                            ForEach(group.models) { model in
+                                let qualifiedName = "\(group.provider)/\(model.id)"
+                                Button(action: {
+                                    onSelect(qualifiedName)
+                                }) {
+                                    HStack(spacing: 0) {
+                                        Text(model.id)
+                                            .font(.system(size: 11, design: .monospaced))
+                                            .foregroundColor(.primary)
+                                        Spacer()
+                                        if hoveredModel == qualifiedName {
+                                            Image(systemName: "plus.circle.fill")
+                                                .font(.system(size: 12))
+                                                .foregroundColor(.accentColor)
+                                        }
+                                    }
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 4)
+                                    .background(hoveredModel == qualifiedName ? Color.accentColor.opacity(0.1) : Color.clear)
+                                    .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .onHover { inside in
+                                    hoveredModel = inside ? qualifiedName : nil
+                                    if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.bottom, 6)
+            }
+        }
+        .frame(width: 300, height: 340)
+    }
+}
+
 struct SettingsView: View {
     @ObservedObject var serverManager: ServerManager
-    @StateObject private var authManager = AuthManager()
+    @ObservedObject var authManager: AuthManager
+    @ObservedObject var codexUsageManager: CodexUsageManager
+    @ObservedObject var claudeUsageManager: ClaudeUsageManager
     @State private var launchAtLogin = false
     @State private var authenticatingService: ServiceType? = nil
     @State private var showingAuthResult = false
@@ -272,6 +660,10 @@ struct SettingsView: View {
     @State private var zaiApiKey = ""
     @State private var pendingRefresh: DispatchWorkItem?
     @State private var expandedRowCount = 0
+    @State private var availableModels: [String: [ModelInfo]] = [:]
+    @State private var modelsLoading = false
+    @State private var modelsError: String?
+    @State private var copiedModelId: String?
     
     private enum Timing {
         static let serverRestartDelay: TimeInterval = 0.3
@@ -330,14 +722,16 @@ struct SettingsView: View {
                         serviceType: .antigravity,
                         iconName: "icon-antigravity.png",
                         accounts: authManager.accounts(for: .antigravity),
+                        disabledAccounts: authManager.manuallyDisabledAccounts.filter { $0.type == .antigravity },
+                        autoDisabledAccounts: authManager.autoDisabledAccounts.filter { $0.type == .antigravity },
                         isAuthenticating: authenticatingService == .antigravity,
                         helpText: "Antigravity provides OAuth-based access to various AI models including Gemini and Claude. One login gives you access to multiple AI services.",
                         isEnabled: serverManager.isProviderEnabled("antigravity"),
                         customTitle: nil,
                         onConnect: { connectService(.antigravity) },
                         onDisconnect: { account in disconnectAccount(account) },
-                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("antigravity", enabled: enabled) },
+                        onToggleAccountEnabled: { account, enabled in toggleAccountEnabled(account, enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
 
@@ -345,46 +739,60 @@ struct SettingsView: View {
                         serviceType: .claude,
                         iconName: "icon-claude.png",
                         accounts: authManager.accounts(for: .claude),
+                        disabledAccounts: authManager.manuallyDisabledAccounts.filter { $0.type == .claude },
+                        autoDisabledAccounts: authManager.autoDisabledAccounts.filter { $0.type == .claude },
                         isAuthenticating: authenticatingService == .claude,
                         helpText: nil,
                         isEnabled: serverManager.isProviderEnabled("claude"),
                         customTitle: serverManager.vercelGatewayEnabled && !serverManager.vercelApiKey.isEmpty ? "Claude Code (via Vercel)" : nil,
                         onConnect: { connectService(.claude) },
                         onDisconnect: { account in disconnectAccount(account) },
-                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("claude", enabled: enabled) },
-                        onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
-                    ) {
-                        VercelGatewayControls(serverManager: serverManager)
+                        onToggleAccountEnabled: { account, enabled in toggleAccountEnabled(account, enabled: enabled) },
+                        onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 },
+                        extraContent: { VercelGatewayControls(serverManager: serverManager) }
+                    ) { account in
+                        if !account.isExpired {
+                            ProviderUsageRow(usage: claudeUsageManager.usage(for: account.id))
+                        }
                     }
 
                     ServiceRow(
                         serviceType: .codex,
                         iconName: "icon-codex.png",
                         accounts: authManager.accounts(for: .codex),
+                        disabledAccounts: authManager.manuallyDisabledAccounts.filter { $0.type == .codex },
+                        autoDisabledAccounts: authManager.autoDisabledAccounts.filter { $0.type == .codex },
                         isAuthenticating: authenticatingService == .codex,
                         helpText: nil,
                         isEnabled: serverManager.isProviderEnabled("codex"),
                         customTitle: nil,
                         onConnect: { connectService(.codex) },
                         onDisconnect: { account in disconnectAccount(account) },
-                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("codex", enabled: enabled) },
-                        onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
-                    ) { EmptyView() }
+                        onToggleAccountEnabled: { account, enabled in toggleAccountEnabled(account, enabled: enabled) },
+                        onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 },
+                        extraContent: { EmptyView() }
+                    ) { account in
+                        if !account.isExpired {
+                            ProviderUsageRow(usage: codexUsageManager.usage(for: account.id))
+                        }
+                    }
 
                     ServiceRow(
                         serviceType: .gemini,
                         iconName: "icon-gemini.png",
                         accounts: authManager.accounts(for: .gemini),
+                        disabledAccounts: authManager.manuallyDisabledAccounts.filter { $0.type == .gemini },
+                        autoDisabledAccounts: authManager.autoDisabledAccounts.filter { $0.type == .gemini },
                         isAuthenticating: authenticatingService == .gemini,
                         helpText: "⚠️ Note: If you're an existing Gemini user with multiple projects, authentication will use your default project. Set your desired project as default in Google AI Studio before connecting.",
                         isEnabled: serverManager.isProviderEnabled("gemini"),
                         customTitle: nil,
                         onConnect: { connectService(.gemini) },
                         onDisconnect: { account in disconnectAccount(account) },
-                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("gemini", enabled: enabled) },
+                        onToggleAccountEnabled: { account, enabled in toggleAccountEnabled(account, enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
 
@@ -392,14 +800,16 @@ struct SettingsView: View {
                         serviceType: .copilot,
                         iconName: "icon-copilot.png",
                         accounts: authManager.accounts(for: .copilot),
+                        disabledAccounts: authManager.manuallyDisabledAccounts.filter { $0.type == .copilot },
+                        autoDisabledAccounts: authManager.autoDisabledAccounts.filter { $0.type == .copilot },
                         isAuthenticating: authenticatingService == .copilot,
                         helpText: "GitHub Copilot provides access to Claude, GPT, Gemini and other models via your Copilot subscription.",
                         isEnabled: serverManager.isProviderEnabled("github-copilot"),
                         customTitle: nil,
                         onConnect: { connectService(.copilot) },
                         onDisconnect: { account in disconnectAccount(account) },
-                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("github-copilot", enabled: enabled) },
+                        onToggleAccountEnabled: { account, enabled in toggleAccountEnabled(account, enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
 
@@ -407,14 +817,16 @@ struct SettingsView: View {
                         serviceType: .qwen,
                         iconName: "icon-qwen.png",
                         accounts: authManager.accounts(for: .qwen),
+                        disabledAccounts: authManager.manuallyDisabledAccounts.filter { $0.type == .qwen },
+                        autoDisabledAccounts: authManager.autoDisabledAccounts.filter { $0.type == .qwen },
                         isAuthenticating: authenticatingService == .qwen,
                         helpText: nil,
                         isEnabled: serverManager.isProviderEnabled("qwen"),
                         customTitle: nil,
                         onConnect: { showingQwenEmailPrompt = true },
                         onDisconnect: { account in disconnectAccount(account) },
-                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("qwen", enabled: enabled) },
+                        onToggleAccountEnabled: { account, enabled in toggleAccountEnabled(account, enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
 
@@ -422,20 +834,135 @@ struct SettingsView: View {
                         serviceType: .zai,
                         iconName: "icon-zai.png",
                         accounts: authManager.accounts(for: .zai),
+                        disabledAccounts: authManager.manuallyDisabledAccounts.filter { $0.type == .zai },
+                        autoDisabledAccounts: authManager.autoDisabledAccounts.filter { $0.type == .zai },
                         isAuthenticating: authenticatingService == .zai,
                         helpText: "Z.AI GLM provides access to GLM-4.7 and other models via API key. Get your key at https://z.ai/manage-apikey/apikey-list",
                         isEnabled: serverManager.isProviderEnabled("zai"),
                         customTitle: nil,
                         onConnect: { showingZaiApiKeyPrompt = true },
                         onDisconnect: { account in disconnectAccount(account) },
-                        onToggleDisabled: { account in toggleAccountDisabled(account) },
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("zai", enabled: enabled) },
+                        onToggleAccountEnabled: { account, enabled in toggleAccountEnabled(account, enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
+
+                }
+
+                Section("Model Groups") {
+                    if serverManager.modelGroups.isEmpty {
+                        VStack(spacing: 4) {
+                            Text("Create a virtual model that round-robins across multiple real models with auto-failover.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    } else {
+                        ForEach($serverManager.modelGroups) { $group in
+                            ModelGroupRow(group: $group, onDelete: {
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    serverManager.modelGroups.removeAll { $0.id == group.id }
+                                }
+                            }, availableModels: availableModels)
+                            if group.id != serverManager.modelGroups.last?.id {
+                                Divider()
+                            }
+                        }
+                    }
+
+                    Button(action: {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            serverManager.modelGroups.append(ModelGroup())
+                        }
+                    }) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "plus.circle.fill")
+                                .font(.caption)
+                            Text("New Group")
+                                .font(.caption)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.accentColor)
+                }
+
+                Section("Available Models") {
+                    if modelsLoading {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Loading models...")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    } else if let error = modelsError {
+                        HStack(spacing: 6) {
+                            Image(systemName: "exclamationmark.circle")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                            Text(error)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    } else if availableModels.isEmpty {
+                        Text("No models available — connect a service above")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    } else {
+                        ForEach(availableModels.keys.sorted(), id: \.self) { provider in
+                            VStack(alignment: .leading, spacing: 6) {
+                                HStack(spacing: 6) {
+                                    Image(systemName: providerIcon(provider))
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                    Text(providerDisplayName(provider))
+                                        .font(.caption)
+                                        .fontWeight(.semibold)
+                                    Text("\(availableModels[provider]?.count ?? 0)")
+                                        .font(.system(size: 9, weight: .medium, design: .monospaced))
+                                        .padding(.horizontal, 5)
+                                        .padding(.vertical, 1)
+                                        .background(Color.accentColor.opacity(0.15))
+                                        .foregroundColor(.accentColor)
+                                        .cornerRadius(3)
+                                }
+
+                                if let models = availableModels[provider] {
+                                    VStack(alignment: .leading, spacing: 3) {
+                                        ForEach(models) { model in
+                                            Button(action: {
+                                                NSPasteboard.general.clearContents()
+                                                NSPasteboard.general.setString(model.id, forType: .string)
+                                                copiedModelId = model.id
+                                                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                                                    if copiedModelId == model.id { copiedModelId = nil }
+                                                }
+                                            }) {
+                                                HStack(spacing: 4) {
+                                                    Text(model.id)
+                                                        .font(.system(size: 11, design: .monospaced))
+                                                        .foregroundColor(.primary)
+                                                    if copiedModelId == model.id {
+                                                        Image(systemName: "checkmark")
+                                                            .font(.system(size: 9, weight: .semibold))
+                                                            .foregroundColor(.green)
+                                                    }
+                                                }
+                                            }
+                                            .buttonStyle(.plain)
+                                            .help("Click to copy")
+                                        }
+                                    }
+                                    .padding(.leading, 22)
+                                }
+                            }
+                            .padding(.vertical, 2)
+                        }
+                    }
                 }
             }
             .formStyle(.grouped)
-            .scrollDisabled(expandedRowCount == 0)
+            .environmentObject(codexUsageManager)
 
             Spacer()
                 .frame(height: 6)
@@ -486,7 +1013,7 @@ struct SettingsView: View {
             }
             .padding(.bottom, 12)
         }
-        .frame(width: 480, height: 740)
+        .frame(width: 480, height: 860)
         .sheet(isPresented: $showingQwenEmailPrompt) {
             VStack(spacing: 16) {
                 Text("Qwen Account Email")
@@ -540,9 +1067,18 @@ struct SettingsView: View {
             .frame(width: 400)
         }
         .onAppear {
-            authManager.checkAuthStatus()
             checkLaunchAtLogin()
             startMonitoringAuthDirectory()
+            if serverManager.isRunning { fetchModels() }
+        }
+        .onChange(of: serverManager.isRunning) { _, running in
+            if running {
+                // Small delay to let server fully start
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { fetchModels() }
+            } else {
+                availableModels = [:]
+                modelsError = nil
+            }
         }
         .onDisappear {
             stopMonitoringAuthDirectory()
@@ -555,20 +1091,6 @@ struct SettingsView: View {
     }
 
     // MARK: - Actions
-    
-    private func toggleAccountDisabled(_ account: AuthAccount) {
-        if authManager.toggleAccountDisabled(account) {
-            authResultSuccess = true
-            authResultMessage = account.isDisabled
-                ? "✓ Enabled \(account.displayName)"
-                : "✓ Disabled \(account.displayName)"
-            showingAuthResult = true
-        } else {
-            authResultSuccess = false
-            authResultMessage = "Failed to update \(account.displayName). Please try again."
-            showingAuthResult = true
-        }
-    }
     
     private func openAuthFolder() {
         let authDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".cli-proxy-api")
@@ -703,6 +1225,49 @@ struct SettingsView: View {
         }
     }
     
+    private func toggleAccountEnabled(_ account: AuthAccount, enabled: Bool) {
+        let wasRunning = serverManager.isRunning
+
+        let action = {
+            let success: Bool
+            if enabled {
+                // Re-enable: check both manual and auto-disabled
+                if self.authManager.isManuallyDisabled(account) {
+                    success = self.authManager.enableAccount(account)
+                } else if self.authManager.isAutoDisabled(account) {
+                    success = self.authManager.autoRestoreAccount(account)
+                } else {
+                    success = false
+                }
+            } else {
+                success = self.authManager.disableAccount(account)
+            }
+
+            if success {
+                self.authResultSuccess = true
+                self.authResultMessage = enabled
+                    ? "✓ Enabled \(account.displayName)"
+                    : "✓ Disabled \(account.displayName)"
+            } else {
+                self.authResultSuccess = false
+                self.authResultMessage = "Failed to \(enabled ? "enable" : "disable") account"
+            }
+            self.showingAuthResult = true
+
+            if wasRunning {
+                DispatchQueue.main.asyncAfter(deadline: .now() + Timing.serverRestartDelay) {
+                    self.serverManager.start { _ in }
+                }
+            }
+        }
+
+        if wasRunning {
+            serverManager.stop { action() }
+        } else {
+            action()
+        }
+    }
+
     private func disconnectAccount(_ account: AuthAccount) {
         let wasRunning = serverManager.isRunning
         
@@ -731,6 +1296,53 @@ struct SettingsView: View {
         }
     }
     
+    // MARK: - Models
+
+    private func fetchModels() {
+        guard let url = URL(string: "http://localhost:8317/v1/models") else { return }
+        modelsLoading = true
+        modelsError = nil
+
+        Task {
+            do {
+                let (data, _) = try await URLSession.shared.data(from: url)
+                let response = try JSONDecoder().decode(ModelsResponse.self, from: data)
+                let grouped = Dictionary(grouping: response.data) { $0.owned_by }
+                    .mapValues { $0.sorted { $0.id < $1.id } }
+                await MainActor.run {
+                    availableModels = grouped
+                    modelsLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    availableModels = [:]
+                    modelsError = "Could not load models"
+                    modelsLoading = false
+                }
+            }
+        }
+    }
+
+    private func providerDisplayName(_ key: String) -> String {
+        switch key {
+        case "anthropic": return "Anthropic"
+        case "openai": return "OpenAI"
+        case "google": return "Google"
+        case "alibaba", "qwen": return "Qwen"
+        case "zhipu", "zai": return "Z.AI"
+        default: return key.capitalized
+        }
+    }
+
+    private func providerIcon(_ key: String) -> String {
+        switch key {
+        case "anthropic": return "a.circle.fill"
+        case "openai": return "o.circle.fill"
+        case "google": return "g.circle.fill"
+        default: return "cpu"
+        }
+    }
+
     // MARK: - File Monitoring
     
     private func startMonitoringAuthDirectory() {

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -1,6 +1,14 @@
 import Foundation
 import Network
 
+private struct UsageStats {
+    var startedAt: Date = Date()
+    var totalRequests: Int = 0
+    var endpointCounts: [String: Int] = [:]
+    var providerCounts: [String: Int] = [:]
+    var modelCounts: [String: Int] = [:]
+}
+
 /**
  A lightweight HTTP proxy that intercepts requests to add extended thinking parameters
  for Claude models based on model name suffixes.
@@ -29,8 +37,19 @@ class ThinkingProxy {
     private let targetHost = "127.0.0.1"
     private(set) var isRunning = false
     private let stateQueue = DispatchQueue(label: "io.automaze.vibeproxy.thinking-proxy-state")
+    private let usageQueue = DispatchQueue(label: "io.automaze.vibeproxy.thinking-proxy-usage")
+    private var usageStats = UsageStats()
 
     var vercelConfig = VercelGatewayConfig(enabled: false, apiKey: "")
+    let modelGroupRouter = ModelGroupRouter()
+
+    private static let statusDateFormatters: [ISO8601DateFormatter] = {
+        let withFractional = ISO8601DateFormatter()
+        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let standard = ISO8601DateFormatter()
+        standard.formatOptions = [.withInternetDateTime]
+        return [withFractional, standard]
+    }()
     
     private enum Config {
         static let hardTokenCap = 32000
@@ -230,6 +249,11 @@ class ThinkingProxy {
         
         let bodyStart = requestString.distance(from: requestString.startIndex, to: bodyStartRange.upperBound)
         let bodyString = String(requestString[requestString.index(requestString.startIndex, offsetBy: bodyStart)...])
+
+        // Local diagnostics endpoints (handled by VibeProxy directly)
+        if handleLocalStatusApi(method: method, path: path, connection: connection) {
+            return
+        }
         
         // Redirect Amp CLI login directly to ampcode.com to preserve auth state cookies
         if path.starts(with: "/auth/cli-login") || path.starts(with: "/api/auth/cli-login") {
@@ -273,6 +297,27 @@ class ThinkingProxy {
                 modifiedBody = stripped
             }
         }
+
+        // Process OpenAI reasoning effort suffix (e.g., gpt-5-reasoning-high)
+        if method == "POST" && !modifiedBody.isEmpty {
+            if let result = processReasoningEffort(jsonString: modifiedBody) {
+                modifiedBody = result
+            }
+        }
+
+        // Resolve model group — rewrite model name to real model via round-robin
+        var modelGroupContext: (groupId: UUID, triedModels: Set<String>)? = nil
+        if method == "POST" && !modifiedBody.isEmpty {
+            if let resolved = resolveModelGroup(body: modifiedBody) {
+                modifiedBody = resolved.rewrittenBody
+                modelGroupContext = (resolved.groupId, [resolved.realModel])
+                NSLog("[ThinkingProxy] Model group resolved: '\(resolved.groupName)' → '\(resolved.realModel)'")
+            }
+        }
+
+        if isCliProxyUsagePath(rewrittenPath) {
+            recordUsage(method: method, path: rewrittenPath, body: modifiedBody)
+        }
         
         // Route Claude requests through Vercel AI Gateway when configured
         if vercelConfig.isActive && method == "POST" && isClaudeModelRequest(body: modifiedBody) {
@@ -280,8 +325,279 @@ class ThinkingProxy {
             forwardToVercel(method: method, path: "/v1/messages", version: httpVersion, headers: headers, body: modifiedBody, thinkingEnabled: thinkingEnabled, originalConnection: connection)
             return
         }
-        
-        forwardRequest(method: method, path: rewrittenPath, version: httpVersion, headers: headers, body: modifiedBody, thinkingEnabled: thinkingEnabled, originalConnection: connection)
+
+        // Intercept /v1/models to inject model groups
+        if method == "GET" && (rewrittenPath == "/v1/models" || rewrittenPath == "/api/v1/models") {
+            let groupNames = modelGroupRouter.activeGroupNames()
+            if !groupNames.isEmpty {
+                forwardRequestAndInjectModels(method: method, path: rewrittenPath, version: httpVersion, headers: headers, body: modifiedBody, groupNames: groupNames, originalConnection: connection)
+                return
+            }
+        }
+
+        forwardRequest(method: method, path: rewrittenPath, version: httpVersion, headers: headers, body: modifiedBody, thinkingEnabled: thinkingEnabled, originalConnection: connection, modelGroupContext: modelGroupContext)
+    }
+
+    private func handleLocalStatusApi(method: String, path: String, connection: NWConnection) -> Bool {
+        let cleanPath = path.components(separatedBy: "?").first ?? path
+
+        if cleanPath == "/vibe/status" {
+            guard method == "GET" else {
+                sendError(to: connection, statusCode: 405, message: "Method Not Allowed")
+                return true
+            }
+
+            let payload = buildStatusPayload()
+            sendJSON(to: connection, payload: payload)
+            return true
+        }
+
+        if cleanPath == "/vibe/usage" {
+            guard method == "GET" else {
+                sendError(to: connection, statusCode: 405, message: "Method Not Allowed")
+                return true
+            }
+
+            let payload = buildUsagePayload()
+            sendJSON(to: connection, payload: payload)
+            return true
+        }
+
+        if cleanPath == "/vibe/usage/reset" {
+            guard method == "POST" else {
+                sendError(to: connection, statusCode: 405, message: "Method Not Allowed")
+                return true
+            }
+
+            usageQueue.sync {
+                usageStats = UsageStats()
+            }
+            sendJSON(to: connection, payload: ["ok": true, "message": "usage counters reset"])
+            return true
+        }
+
+        return false
+    }
+
+    private func sendJSON(to connection: NWConnection, payload: [String: Any]) {
+        guard JSONSerialization.isValidJSONObject(payload),
+              let bodyData = try? JSONSerialization.data(withJSONObject: payload),
+              let headers = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \(bodyData.count)\r\nConnection: close\r\n\r\n".data(using: .utf8) else {
+            sendError(to: connection, statusCode: 500, message: "Internal Server Error")
+            return
+        }
+
+        var responseData = Data()
+        responseData.append(headers)
+        responseData.append(bodyData)
+
+        connection.send(content: responseData, completion: .contentProcessed({ _ in
+            connection.cancel()
+        }))
+    }
+
+    private func isCliProxyUsagePath(_ path: String) -> Bool {
+        path.starts(with: "/v1/") || path.starts(with: "/api/v1/")
+    }
+
+    private func normalizedEndpoint(_ path: String) -> String {
+        let noQuery = path.components(separatedBy: "?").first ?? path
+        if noQuery.starts(with: "/api/") {
+            return String(noQuery.dropFirst(4))
+        }
+        return noQuery
+    }
+
+    private func extractModel(from body: String) -> String? {
+        guard let data = body.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let model = json["model"] as? String,
+              !model.isEmpty else {
+            return nil
+        }
+        return model
+    }
+
+    private func providerForModel(_ model: String?) -> String {
+        guard let model else { return "unknown" }
+        let lower = model.lowercased()
+        if lower.starts(with: "claude-") { return "claude" }
+        if lower.starts(with: "gpt-") || lower.contains("codex") || lower.starts(with: "o3") || lower.starts(with: "o4") { return "codex" }
+        if lower.starts(with: "gemini-") {
+            if lower.starts(with: "gemini-claude-") {
+                return "antigravity"
+            }
+            return "gemini"
+        }
+        if lower.starts(with: "qwen") { return "qwen" }
+        if lower.starts(with: "glm") { return "zai" }
+        if lower.starts(with: "amazonq") || lower.contains("copilot") { return "github-copilot" }
+        return "other"
+    }
+
+    private func recordUsage(method: String, path: String, body: String) {
+        let endpoint = "\(method.uppercased()) \(normalizedEndpoint(path))"
+        let model = extractModel(from: body)
+        let provider = providerForModel(model)
+
+        usageQueue.async {
+            self.usageStats.totalRequests += 1
+            self.usageStats.endpointCounts[endpoint, default: 0] += 1
+            self.usageStats.providerCounts[provider, default: 0] += 1
+            if let model {
+                self.usageStats.modelCounts[model, default: 0] += 1
+            }
+        }
+    }
+
+    /// Thread-safe snapshot of per-provider request counts.
+    func providerRequestCounts() -> [String: Int] {
+        usageQueue.sync { usageStats.providerCounts }
+    }
+
+    private func buildUsagePayload() -> [String: Any] {
+        let snapshot = usageQueue.sync { usageStats }
+        let accounts = loadAuthAccounts()
+        let grouped = Dictionary(grouping: accounts) { $0.type }
+
+        var rotation: [String: Any] = [:]
+        for (provider, providerAccounts) in grouped {
+            let active = providerAccounts.filter { !$0.isExpired }.sorted { $0.id < $1.id }
+            guard active.count > 1 else { continue }
+            let count = snapshot.providerCounts[provider] ?? 0
+            let lastIdx = count > 0 ? (count - 1) % active.count : nil
+            let nextIdx = count % active.count
+            rotation[provider] = [
+                "last_used": lastIdx.map { active[$0].displayName } as Any,
+                "next": active[nextIdx].displayName,
+                "request_count": count,
+                "active_accounts": active.count
+            ]
+        }
+
+        return [
+            "started_at": iso8601(snapshot.startedAt),
+            "generated_at": iso8601(Date()),
+            "total_requests": snapshot.totalRequests,
+            "endpoint_counts": snapshot.endpointCounts,
+            "provider_counts": snapshot.providerCounts,
+            "model_counts": snapshot.modelCounts,
+            "account_rotation": rotation,
+            "note": "Counts are based on inbound proxy requests (not confirmed backend account selection)."
+        ]
+    }
+
+    private func buildStatusPayload() -> [String: Any] {
+        let accounts = loadAuthAccounts()
+        let grouped = Dictionary(grouping: accounts) { $0.type }
+
+        var byProvider: [String: Any] = [:]
+        for (provider, providerAccounts) in grouped {
+            let active = providerAccounts.filter { !$0.isExpired }
+            let expired = providerAccounts.filter { $0.isExpired }
+
+            byProvider[provider] = [
+                "total": providerAccounts.count,
+                "active": active.count,
+                "expired": expired.count,
+                "accounts": providerAccounts.map { account in
+                    var entry: [String: Any] = [
+                        "id": account.id,
+                        "display_name": account.displayName,
+                        "expired": account.isExpired,
+                        "file": account.fileName
+                    ]
+                    if let date = account.expired {
+                        entry["expires_at"] = iso8601(date)
+                    }
+                    return entry
+                }
+            ]
+        }
+
+        let total = accounts.count
+        let activeTotal = accounts.filter { !$0.isExpired }.count
+
+        return [
+            "generated_at": iso8601(Date()),
+            "proxy": [
+                "host": "127.0.0.1",
+                "port": proxyPort,
+                "target_port": targetPort,
+                "running": isRunning
+            ],
+            "accounts": [
+                "total": total,
+                "active": activeTotal,
+                "expired": total - activeTotal,
+                "providers": byProvider
+            ]
+        ]
+    }
+
+    private struct LocalAuthAccount {
+        let id: String
+        let fileName: String
+        let type: String
+        let email: String?
+        let login: String?
+        let expired: Date?
+
+        var isExpired: Bool {
+            guard let expired else { return false }
+            return expired < Date()
+        }
+
+        var displayName: String {
+            if let email, !email.isEmpty { return email }
+            if let login, !login.isEmpty { return login }
+            return id
+        }
+    }
+
+    private func loadAuthAccounts() -> [LocalAuthAccount] {
+        let authDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".cli-proxy-api")
+        guard let files = try? FileManager.default.contentsOfDirectory(at: authDir, includingPropertiesForKeys: nil) else {
+            return []
+        }
+
+        var accounts: [LocalAuthAccount] = []
+
+        for file in files where file.pathExtension == "json" {
+            guard let data = try? Data(contentsOf: file),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let type = json["type"] as? String else {
+                continue
+            }
+
+            let expiredString = json["expired"] as? String
+            let expiredDate = parseDate(expiredString)
+
+            accounts.append(LocalAuthAccount(
+                id: file.lastPathComponent,
+                fileName: file.lastPathComponent,
+                type: type.lowercased(),
+                email: json["email"] as? String,
+                login: json["login"] as? String,
+                expired: expiredDate
+            ))
+        }
+
+        return accounts.sorted { $0.type < $1.type }
+    }
+
+    private func parseDate(_ value: String?) -> Date? {
+        guard let value else { return nil }
+        for formatter in Self.statusDateFormatters {
+            if let date = formatter.date(from: value) {
+                return date
+            }
+        }
+        return nil
+    }
+
+    private func iso8601(_ date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
     }
     
     private func isClaudeModelRequest(body: String) -> Bool {
@@ -451,6 +767,103 @@ class ThinkingProxy {
         return (jsonString, false)  // No transformation needed
     }
     
+    // MARK: - OpenAI Reasoning Effort
+
+    private static let validReasoningEfforts: Set<String> = ["none", "minimal", "low", "medium", "high", "xhigh"]
+
+    /// Processes the JSON body to add reasoning effort if model name has a `-reasoning-LEVEL` suffix.
+    /// E.g. `gpt-5.3-codex-reasoning-high` → strips suffix, injects `{"reasoning": {"effort": "high"}}`.
+    private func processReasoningEffort(jsonString: String) -> String? {
+        guard let jsonData = jsonString.data(using: .utf8),
+              var json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+              let model = json["model"] as? String else {
+            return nil
+        }
+
+        // Skip Claude models (handled by processThinkingParameter)
+        guard !model.starts(with: "claude-") && !model.starts(with: "gemini-claude-") else {
+            return nil
+        }
+
+        // Check for -reasoning-LEVEL suffix
+        let reasoningPrefix = "-reasoning-"
+        guard let range = model.range(of: reasoningPrefix, options: .backwards),
+              range.upperBound < model.endIndex else {
+            return nil
+        }
+
+        let effort = String(model[range.upperBound...]).lowercased()
+        guard Self.validReasoningEfforts.contains(effort) else {
+            NSLog("[ThinkingProxy] Invalid reasoning effort '\(effort)' in model '\(model)'")
+            return nil
+        }
+
+        let cleanModel = String(model[..<range.lowerBound])
+        json["model"] = cleanModel
+        json["reasoning"] = ["effort": effort]
+
+        NSLog("[ThinkingProxy] Transformed model '\(model)' → '\(cleanModel)' with reasoning effort '\(effort)'")
+
+        guard let modifiedData = try? JSONSerialization.data(withJSONObject: json),
+              let modifiedString = String(data: modifiedData, encoding: .utf8) else {
+            return nil
+        }
+        return modifiedString
+    }
+
+    // MARK: - Model Group Resolution
+
+    private struct ModelGroupResolution {
+        let groupName: String
+        let groupId: UUID
+        let realModel: String
+        let rewrittenBody: String
+    }
+
+    private func resolveModelGroup(body: String) -> ModelGroupResolution? {
+        guard let data = body.data(using: .utf8),
+              var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let model = json["model"] as? String else {
+            return nil
+        }
+        guard let resolved = modelGroupRouter.resolveModel(model) else { return nil }
+
+        // Strip provider prefix (e.g., "github-copilot/claude-opus-4-6" → "claude-opus-4-6")
+        let realModel: String
+        if let slashIndex = resolved.realModel.firstIndex(of: "/") {
+            realModel = String(resolved.realModel[resolved.realModel.index(after: slashIndex)...])
+        } else {
+            realModel = resolved.realModel
+        }
+
+        json["model"] = realModel
+        guard let modifiedData = try? JSONSerialization.data(withJSONObject: json),
+              let modifiedString = String(data: modifiedData, encoding: .utf8) else {
+            return nil
+        }
+        return ModelGroupResolution(groupName: model, groupId: resolved.groupId, realModel: realModel, rewrittenBody: modifiedString)
+    }
+
+    private func rewriteModelInBody(_ body: String, to newModel: String) -> String? {
+        guard let data = body.data(using: .utf8),
+              var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        // Strip provider prefix if present
+        let modelId: String
+        if let slashIndex = newModel.firstIndex(of: "/") {
+            modelId = String(newModel[newModel.index(after: slashIndex)...])
+        } else {
+            modelId = newModel
+        }
+        json["model"] = modelId
+        guard let modified = try? JSONSerialization.data(withJSONObject: json),
+              let result = String(data: modified, encoding: .utf8) else {
+            return nil
+        }
+        return result
+    }
+
     /**
      Forwards Amp API requests to ampcode.com, stripping the /api/ prefix
      */
@@ -694,7 +1107,7 @@ class ThinkingProxy {
     /**
      Forwards the request to CLIProxyAPI on port 8318 (pass-through for non-thinking requests)
      */
-    private func forwardRequest(method: String, path: String, version: String, headers: [(String, String)], body: String, thinkingEnabled: Bool = false, originalConnection: NWConnection, retryWithApiPrefix: Bool = false) {
+    private func forwardRequest(method: String, path: String, version: String, headers: [(String, String)], body: String, thinkingEnabled: Bool = false, originalConnection: NWConnection, retryWithApiPrefix: Bool = false, modelGroupContext: (groupId: UUID, triedModels: Set<String>)? = nil) {
         // Create connection to CLIProxyAPI
         guard let port = NWEndpoint.Port(rawValue: targetPort) else {
             NSLog("[ThinkingProxy] Invalid target port: %d", targetPort)
@@ -762,10 +1175,19 @@ class ThinkingProxy {
                             targetConnection.cancel()
                             originalConnection.cancel()
                         } else {
-                            // Receive response from CLIProxyAPI (with 404 retry capability)
-                            if retryWithApiPrefix {
-                                self.receiveResponseWith404Retry(from: targetConnection, originalConnection: originalConnection, 
-                                                                 method: method, path: path, version: version, 
+                            // Receive response from CLIProxyAPI
+                            if let groupCtx = modelGroupContext {
+                                self.receiveResponseWithGroupFailover(
+                                    from: targetConnection,
+                                    originalConnection: originalConnection,
+                                    method: method, path: path, version: version,
+                                    headers: headers, body: body,
+                                    thinkingEnabled: thinkingEnabled,
+                                    groupContext: groupCtx
+                                )
+                            } else if retryWithApiPrefix {
+                                self.receiveResponseWith404Retry(from: targetConnection, originalConnection: originalConnection,
+                                                                 method: method, path: path, version: version,
                                                                  headers: headers, body: body)
                             } else {
                                 self.receiveResponse(from: targetConnection, originalConnection: originalConnection)
@@ -906,6 +1328,224 @@ class ThinkingProxy {
         }
     }
     
+    // MARK: - Model Group /v1/models Injection
+
+    private func forwardRequestAndInjectModels(method: String, path: String, version: String, headers: [(String, String)], body: String, groupNames: [String], originalConnection: NWConnection) {
+        guard let port = NWEndpoint.Port(rawValue: targetPort) else {
+            sendError(to: originalConnection, statusCode: 500, message: "Internal Server Error")
+            return
+        }
+        let endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(targetHost), port: port)
+        let targetConnection = NWConnection(to: endpoint, using: NWParameters.tcp)
+
+        targetConnection.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                var req = "\(method) \(path) \(version)\r\n"
+                let excluded: Set<String> = ["content-length", "host", "transfer-encoding"]
+                for (name, value) in headers where !excluded.contains(name.lowercased()) {
+                    req += "\(name): \(value)\r\n"
+                }
+                req += "Host: \(self.targetHost):\(self.targetPort)\r\n"
+                req += "Connection: close\r\n"
+                let contentLength = body.utf8.count
+                req += "Content-Length: \(contentLength)\r\n\r\n\(body)"
+
+                if let data = req.data(using: .utf8) {
+                    targetConnection.send(content: data, completion: .contentProcessed({ error in
+                        if let error = error {
+                            NSLog("[ThinkingProxy] Models inject send error: \(error)")
+                            targetConnection.cancel()
+                            originalConnection.cancel()
+                        } else {
+                            self.bufferFullResponse(from: targetConnection) { responseData in
+                                guard let responseData = responseData else {
+                                    self.sendError(to: originalConnection, statusCode: 502, message: "Bad Gateway")
+                                    return
+                                }
+                                let injected = self.injectGroupModels(into: responseData, groupNames: groupNames)
+                                originalConnection.send(content: injected, completion: .contentProcessed({ _ in
+                                    originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
+                                        originalConnection.cancel()
+                                    }))
+                                }))
+                            }
+                        }
+                    }))
+                }
+            case .failed(let error):
+                NSLog("[ThinkingProxy] Models inject connection failed: \(error)")
+                self.sendError(to: originalConnection, statusCode: 502, message: "Bad Gateway")
+                targetConnection.cancel()
+            default: break
+            }
+        }
+        targetConnection.start(queue: .global(qos: .userInitiated))
+    }
+
+    private func bufferFullResponse(from connection: NWConnection, accumulated: Data = Data(), completion: @escaping (Data?) -> Void) {
+        // Guard against unbounded buffering (4 MB max for /v1/models responses)
+        if accumulated.count > 4 * 1024 * 1024 {
+            NSLog("[ThinkingProxy] Buffer response exceeded 4 MB limit")
+            connection.cancel()
+            completion(nil)
+            return
+        }
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { data, _, isComplete, error in
+            if let error = error {
+                NSLog("[ThinkingProxy] Buffer response error: \(error)")
+                connection.cancel()
+                completion(nil)
+                return
+            }
+            var buffer = accumulated
+            if let data = data { buffer.append(data) }
+            if isComplete {
+                connection.cancel()
+                completion(buffer)
+            } else {
+                self.bufferFullResponse(from: connection, accumulated: buffer, completion: completion)
+            }
+        }
+    }
+
+    private func injectGroupModels(into responseData: Data, groupNames: [String]) -> Data {
+        guard let responseStr = String(data: responseData, encoding: .utf8),
+              let headerEnd = responseStr.range(of: "\r\n\r\n") else {
+            return responseData
+        }
+
+        let headerSection = String(responseStr[responseStr.startIndex..<headerEnd.lowerBound])
+        let bodyStr = String(responseStr[headerEnd.upperBound...])
+        guard let bodyData = bodyStr.data(using: .utf8),
+              var json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any],
+              var dataArray = json["data"] as? [[String: Any]] else {
+            return responseData
+        }
+
+        for name in groupNames {
+            dataArray.append([
+                "id": name,
+                "object": "model",
+                "created": Int(Date().timeIntervalSince1970),
+                "owned_by": "vibeproxy"
+            ])
+        }
+        json["data"] = dataArray
+
+        guard let newBody = try? JSONSerialization.data(withJSONObject: json),
+              let newBodyStr = String(data: newBody, encoding: .utf8) else {
+            return responseData
+        }
+
+        // Preserve original headers, only update Content-Length
+        var headerLines = headerSection.components(separatedBy: "\r\n")
+        headerLines = headerLines.map { line in
+            if line.lowercased().hasPrefix("content-length:") {
+                return "Content-Length: \(newBody.count)"
+            }
+            return line
+        }
+
+        let newResponse = headerLines.joined(separator: "\r\n") + "\r\n\r\n" + newBodyStr
+        return newResponse.data(using: .utf8) ?? responseData
+    }
+
+    // MARK: - Model Group Failover
+
+    private func receiveResponseWithGroupFailover(
+        from targetConnection: NWConnection,
+        originalConnection: NWConnection,
+        method: String, path: String, version: String,
+        headers: [(String, String)], body: String,
+        thinkingEnabled: Bool,
+        groupContext: (groupId: UUID, triedModels: Set<String>)
+    ) {
+        targetConnection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                NSLog("[ThinkingProxy] Group failover receive error: \(error)")
+                targetConnection.cancel()
+                self.sendError(to: originalConnection, statusCode: 502, message: "Bad Gateway")
+                return
+            }
+
+            guard let data = data, !data.isEmpty else {
+                if isComplete {
+                    targetConnection.cancel()
+                    originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
+                        originalConnection.cancel()
+                    }))
+                }
+                return
+            }
+
+            let statusCode = self.extractHttpStatus(from: data)
+            let isRetryable = [429, 500, 502, 503].contains(statusCode)
+
+            if isRetryable {
+                NSLog("[ThinkingProxy] Model group got \(statusCode ?? 0), attempting failover")
+                targetConnection.cancel()
+                self.retryWithNextGroupModel(
+                    originalConnection: originalConnection,
+                    method: method, path: path, version: version,
+                    headers: headers, body: body,
+                    thinkingEnabled: thinkingEnabled,
+                    groupContext: groupContext
+                )
+            } else {
+                originalConnection.send(content: data, completion: .contentProcessed({ sendError in
+                    if let sendError = sendError {
+                        NSLog("[ThinkingProxy] Send response error: \(sendError)")
+                    }
+                    if isComplete {
+                        targetConnection.cancel()
+                        originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
+                            originalConnection.cancel()
+                        }))
+                    } else {
+                        self.streamNextChunk(from: targetConnection, to: originalConnection)
+                    }
+                }))
+            }
+        }
+    }
+
+    private func retryWithNextGroupModel(
+        originalConnection: NWConnection,
+        method: String, path: String, version: String,
+        headers: [(String, String)], body: String,
+        thinkingEnabled: Bool,
+        groupContext: (groupId: UUID, triedModels: Set<String>)
+    ) {
+        guard let nextModel = modelGroupRouter.failoverModel(groupId: groupContext.groupId, excluding: groupContext.triedModels),
+              let rewrittenBody = rewriteModelInBody(body, to: nextModel) else {
+            NSLog("[ThinkingProxy] Model group exhausted all models, returning 503")
+            sendError(to: originalConnection, statusCode: 503, message: "All models in group exhausted")
+            return
+        }
+
+        NSLog("[ThinkingProxy] Model group failover → '\(nextModel)'")
+        var updatedContext = groupContext
+        updatedContext.triedModels.insert(nextModel)
+
+        forwardRequest(
+            method: method, path: path, version: version,
+            headers: headers, body: rewrittenBody,
+            thinkingEnabled: thinkingEnabled,
+            originalConnection: originalConnection,
+            modelGroupContext: updatedContext
+        )
+    }
+
+    private func extractHttpStatus(from data: Data) -> Int? {
+        guard let str = String(data: data.prefix(32), encoding: .utf8) else { return nil }
+        let parts = str.components(separatedBy: " ")
+        guard parts.count >= 2, let code = Int(parts[1]) else { return nil }
+        return code
+    }
+
     /**
      Sends an error response to the client
      */

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -1409,6 +1409,8 @@ class ThinkingProxy {
         }
     }
 
+    private static let reasoningEfforts = ["low", "medium", "high"]
+
     private func injectGroupModels(into responseData: Data, groupNames: [String]) -> Data {
         guard let responseStr = String(data: responseData, encoding: .utf8),
               let headerEnd = responseStr.range(of: "\r\n\r\n") else {
@@ -1423,11 +1425,29 @@ class ThinkingProxy {
             return responseData
         }
 
+        // Inject reasoning/thinking variants for existing models
+        let now = Int(Date().timeIntervalSince1970)
+        let existingModels = dataArray.compactMap { $0["id"] as? String }
+        for modelId in existingModels {
+            let owner = dataArray.first(where: { $0["id"] as? String == modelId })?["owned_by"] as? String ?? "vibeproxy"
+            if modelId.starts(with: "claude-") || modelId.starts(with: "gemini-claude-") {
+                // Claude: add -thinking-{8000,16000,32000} variants
+                for budget in [8000, 16000, 32000] {
+                    dataArray.append(["id": "\(modelId)-thinking-\(budget)", "object": "model", "created": now, "owned_by": owner])
+                }
+            } else {
+                // Non-Claude: add -reasoning-{low,medium,high} variants
+                for effort in Self.reasoningEfforts {
+                    dataArray.append(["id": "\(modelId)-reasoning-\(effort)", "object": "model", "created": now, "owned_by": owner])
+                }
+            }
+        }
+
         for name in groupNames {
             dataArray.append([
                 "id": name,
                 "object": "model",
-                "created": Int(Date().timeIntervalSince1970),
+                "created": now,
                 "owned_by": "vibeproxy"
             ])
         }

--- a/src/Sources/main.swift
+++ b/src/Sources/main.swift
@@ -1,7 +1,7 @@
 import Cocoa
 
 let app = NSApplication.shared
-let delegate = AppDelegate()
+let delegate = MainActor.assumeIsolated { AppDelegate() }
 app.delegate = delegate
 
 _ = NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)

--- a/vibeproxy_dmg_temp/Applications
+++ b/vibeproxy_dmg_temp/Applications
@@ -1,0 +1,1 @@
+/Applications


### PR DESCRIPTION
## Summary

- **Per-account usage monitoring** for Claude and Codex providers with real-time polling, usage pills (remaining %, reset time), and menu bar usage display via `MenuBarUsageItemsController`
- **Auto-disable/restore accounts** based on usage — accounts hitting 0% are moved to `.disabled/.auto/` and automatically restored when usage recovers
- **Manual account disable/enable** via file-system approach (moving files to `.disabled/` directory) replacing the previous in-JSON `disabled` flag
- **Model Groups** — virtual models that round-robin requests across multiple real models from different providers with automatic failover on 429/5xx errors
- **Available Models section** in Settings — fetches and displays all models from `/v1/models`, grouped by provider, with click-to-copy
- **Model Group UI** — create/edit/delete model groups with a searchable model picker popover
- **ThinkingProxy enhancements** — model group resolution, `/v1/models` interception to inject group models, failover routing with retry logic
- **Auth directory monitoring** in AppDelegate for detecting credential file changes
- **SettingsView refactor** — extracted `servicesSection`, `modelGroupsSection`, and `availableModelsSection` into computed properties to fix Swift compiler type-check timeout

## New Files

| File | Purpose |
|------|---------|
| `ClaudeUsageManager.swift` | Polls Claude API for per-account usage data |
| `CodexUsageManager.swift` | Polls Codex API for per-account usage data |
| `MenuBarUsageView.swift` | Menu bar usage items controller with auto-refresh |
| `ModelGroup.swift` | Model group data model + round-robin router |

## Modified Files

| File | Changes |
|------|---------|
| `AppDelegate.swift` | Added usage polling, auto-disable logic, menu bar usage controller, auth directory monitoring |
| `AuthStatus.swift` | File-system based disable/enable (manual + auto), removed `isDisabled` JSON flag approach |
| `SettingsView.swift` | Per-account usage rows, model groups UI, available models section, account toggle switches, compiler fix |
| `ThinkingProxy.swift` | Model group resolution, `/v1/models` interception, failover routing |
| `ServerManager.swift` | Model groups persistence, provider enable/disable config generation |

## Test plan

- [ ] Verify usage pills display correctly for Claude and Codex accounts
- [ ] Test auto-disable triggers when account hits 0% usage
- [ ] Test auto-restore when usage recovers
- [ ] Test manual account disable/enable via toggle switches
- [ ] Create a model group with models from multiple providers and verify round-robin
- [ ] Verify failover when one provider returns 429/5xx
- [ ] Check Available Models section populates when server is running
- [ ] Verify menu bar usage items update on 3s interval
- [ ] Build and run the .app bundle successfully