### PR TITLE
feat: Opus 4.6/Sonnet 4.6 support + fix prompt cache invalidation

### DIFF
--- a/FACTORY_SETUP.md
+++ b/FACTORY_SETUP.md
@@ -611,6 +611,35 @@ You don't need to configure anything - when you use any `-thinking-*` model vari
 
 This is enabled by default because if you're opting into extended thinking, you almost certainly want the improved reasoning that interleaved thinking provides for tool-heavy workflows.
 
+## Recommended Settings for Peak Performance
+
+For the best experience, add the Opus 4.6 Max model directly in Factory's `settings.json` (`~/.factory/settings.json`) under `customModels`. This lets you set `maxOutputTokens` to unlock the full 128K output window, which `config.json` doesn't support:
+
+```json
+{
+  "model": "claude-opus-4-6-thinking-128000",
+  "id": "custom:CC:-Opus-4.6-(Max)-0",
+  "index": 0,
+  "baseUrl": "http://localhost:8317",
+  "apiKey": "dummy-not-used",
+  "displayName": "CC: Opus 4.6 (Max)",
+  "maxOutputTokens": 128000,
+  "noImageSupport": false,
+  "provider": "anthropic"
+}
+```
+
+Then set it as your default model in `sessionDefaultSettings`:
+
+```json
+"sessionDefaultSettings": {
+  "model": "custom:CC:-Opus-4.6-(Max)-0"
+}
+```
+
+> [!TIP]
+> The key advantage of `settings.json` over `config.json` is the `maxOutputTokens` field — without it, Factory may cap output well below the 128K that Opus 4.6 supports.
+
 ## Tips
 
 - **Launch at Login**: Enable in VibeProxy settings to auto-start the server

--- a/FACTORY_SETUP.md
+++ b/FACTORY_SETUP.md
@@ -131,6 +131,49 @@ Edit your Factory configuration file at `~/.factory/config.json` (if the file do
     },
 
     {
+      "model_display_name": "CC: Opus 4.6",
+      "model": "claude-opus-4-6",
+      "base_url": "http://localhost:8317",
+      "api_key": "dummy-not-used",
+      "provider": "anthropic"
+    },
+    {
+      "model_display_name": "CC: Opus 4.6 (High)",
+      "model": "claude-opus-4-6-thinking-64000",
+      "base_url": "http://localhost:8317",
+      "api_key": "dummy-not-used",
+      "provider": "anthropic"
+    },
+    {
+      "model_display_name": "CC: Opus 4.6 (Max)",
+      "model": "claude-opus-4-6-thinking-128000",
+      "base_url": "http://localhost:8317",
+      "api_key": "dummy-not-used",
+      "provider": "anthropic"
+    },
+    {
+      "model_display_name": "CC: Sonnet 4.6",
+      "model": "claude-sonnet-4-6",
+      "base_url": "http://localhost:8317",
+      "api_key": "dummy-not-used",
+      "provider": "anthropic"
+    },
+    {
+      "model_display_name": "CC: Sonnet 4.6 (High)",
+      "model": "claude-sonnet-4-6-thinking-64000",
+      "base_url": "http://localhost:8317",
+      "api_key": "dummy-not-used",
+      "provider": "anthropic"
+    },
+    {
+      "model_display_name": "CC: Sonnet 4.6 (Max)",
+      "model": "claude-sonnet-4-6-thinking-128000",
+      "base_url": "http://localhost:8317",
+      "api_key": "dummy-not-used",
+      "provider": "anthropic"
+    },
+
+    {
       "model_display_name": "AG: Opus 4.5 Thinking",
       "model": "gemini-claude-opus-4-5-thinking",
       "base_url": "http://localhost:8317/v1",
@@ -518,10 +561,25 @@ If the suffix is not a valid integer (e.g., `-thinking-blabla`), VibeProxy strip
 - Transparent thought process in the response
 
 **Supported Models**:
-- Claude Opus 4.5 (`claude-opus-4-5-*`)
-- Claude Sonnet 4.5 (`claude-sonnet-4-5-*`)
+- Claude Opus 4.6 (`claude-opus-4-6*`) — **Adaptive thinking**, 128K output, 1M context
+- Claude Sonnet 4.6 (`claude-sonnet-4-6*`) — **Adaptive thinking**, 128K output, 1M context
+- Claude Opus 4.5 (`claude-opus-4-5-*`) — Budget-based thinking, 64K output, 200K context
+- Claude Sonnet 4.5 (`claude-sonnet-4-5-*`) — Budget-based thinking, 64K output, 1M context
 
 This works seamlessly with Factory CLI - just select the thinking variant in your model selector!
+
+### Adaptive Thinking (Opus 4.6+, Sonnet 4.6+)
+
+Claude Opus 4.6 and Sonnet 4.6 use **adaptive thinking** instead of a fixed token budget. With adaptive thinking, Claude automatically decides how much to think based on prompt complexity — there is no explicit `budget_tokens` parameter.
+
+The `-thinking-NUMBER` suffix still works for these models, but instead of setting a thinking budget, it sets a **max output token floor** that gives the model more room for both thinking and response output (up to 128K).
+
+**Recommended presets for 4.6 models:**
+- `claude-opus-4-6-thinking-64000` → **High** output room (64K floor)
+- `claude-opus-4-6-thinking-128000` → **Max** output room (128K floor)
+
+> [!TIP]
+> For most use cases, the base `claude-opus-4-6` or `claude-sonnet-4-6` model (without a thinking suffix) is sufficient — adaptive thinking is always enabled when requested via the thinking suffix, and the API will allocate output tokens as needed.
 
 ### Interleaved Thinking (Automatic)
 

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -30,6 +30,25 @@ class ThinkingProxy {
     private(set) var isRunning = false
     private let stateQueue = DispatchQueue(label: "io.automaze.vibeproxy.thinking-proxy-state")
 
+    /// File-based debug logger (writes to /tmp/vibeproxy-debug.log)
+    private static let logFile: URL = URL(fileURLWithPath: "/tmp/vibeproxy-debug.log")
+    private static let logQueue = DispatchQueue(label: "io.automaze.vibeproxy.file-log")
+    static func fileLog(_ message: String) {
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let line = "[\(timestamp)] \(message)\n"
+        logQueue.async {
+            if let data = line.data(using: .utf8) {
+                if let handle = try? FileHandle(forWritingTo: logFile) {
+                    handle.seekToEndOfFile()
+                    handle.write(data)
+                    handle.closeFile()
+                } else {
+                    try? data.write(to: logFile)
+                }
+            }
+        }
+    }
+
     var vercelConfig = VercelGatewayConfig(enabled: false, apiKey: "")
     
     private enum Config {
@@ -41,14 +60,16 @@ class ThinkingProxy {
         static let anthropicVersion = "2023-06-01"
 
         /// Models that support extended output (128K) and adaptive thinking
-        private static let extendedModels = ["opus-4-6", "opus-4-7", "sonnet-4-6", "sonnet-4-7"]
+        private static let adaptiveModels = ["opus-4-6", "opus-4-7", "sonnet-4-6", "sonnet-4-7"]
+
+        /// Whether the model supports adaptive thinking (Opus 4.6+, Sonnet 4.6+)
+        static func isAdaptiveModel(_ model: String) -> Bool {
+            adaptiveModels.contains(where: { model.contains($0) })
+        }
 
         /// Returns the max output token cap for a given (cleaned) model name.
         static func hardTokenCap(for model: String) -> Int {
-            if extendedModels.contains(where: { model.contains($0) }) {
-                return extendedHardTokenCap
-            }
-            return defaultHardTokenCap
+            isAdaptiveModel(model) ? extendedHardTokenCap : defaultHardTokenCap
         }
     }
     
@@ -276,16 +297,14 @@ class ThinkingProxy {
         var thinkingEnabled = false
         
         if method == "POST" && !bodyString.isEmpty {
+            ThinkingProxy.fileLog("INCOMING REQUEST: \(method) \(rewrittenPath)")
+            ThinkingProxy.fileLog("ORIGINAL BODY (first 500): \(String(bodyString.prefix(500)))")
             if let result = processThinkingParameter(jsonString: bodyString) {
                 modifiedBody = result.0
                 thinkingEnabled = result.1
+                ThinkingProxy.fileLog("MODIFIED BODY (first 500): \(String(modifiedBody.prefix(500)))")
+                ThinkingProxy.fileLog("THINKING ENABLED: \(thinkingEnabled)")
             }
-            // NOTE: Stripping cache_control fields breaks Claude's prompt caching feature,
-            // causing excessive token usage in long-running conversations.
-            // Disabled to restore prompt caching and reduce usage.
-            // if let stripped = stripCacheControl(from: modifiedBody) {
-            //     modifiedBody = stripped
-            // }
         }
         
         // Route Claude requests through Vercel AI Gateway when configured
@@ -305,57 +324,10 @@ class ThinkingProxy {
         return model.starts(with: "claude-") || model.starts(with: "gemini-claude-")
     }
 
-    /// Strips `cache_control` fields from the request body that cause 400 errors via the OAuth route
-    private func stripCacheControl(from jsonString: String) -> String? {
-        guard let jsonData = jsonString.data(using: .utf8),
-              var json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
-            return nil
-        }
-
-        var modified = false
-
-        func stripFromDictArray(_ array: inout [[String: Any]]) {
-            for i in array.indices {
-                if array[i]["cache_control"] != nil {
-                    array[i].removeValue(forKey: "cache_control")
-                    modified = true
-                }
-                // Recurse into nested content arrays
-                if var nested = array[i]["content"] as? [[String: Any]] {
-                    stripFromDictArray(&nested)
-                    array[i]["content"] = nested
-                }
-            }
-        }
-
-        if var system = json["system"] as? [[String: Any]] {
-            stripFromDictArray(&system)
-            if modified { json["system"] = system }
-        }
-
-        if var messages = json["messages"] as? [[String: Any]] {
-            stripFromDictArray(&messages)
-            if modified { json["messages"] = messages }
-        }
-
-        if var tools = json["tools"] as? [[String: Any]] {
-            stripFromDictArray(&tools)
-            if modified { json["tools"] = tools }
-        }
-
-        guard modified else { return nil }
-
-        guard let modifiedData = try? JSONSerialization.data(withJSONObject: json),
-              let modifiedString = String(data: modifiedData, encoding: .utf8) else {
-            return nil
-        }
-
-        NSLog("[ThinkingProxy] Stripped cache_control fields from request body")
-        return modifiedString
-    }
-    
     /**
-     Processes the JSON body to add thinking parameter if model name has a thinking suffix
+     Processes the JSON body to add thinking parameter if model name has a thinking suffix.
+     Uses surgical string operations to preserve original JSON structure and key ordering,
+     which is critical for Anthropic's prompt caching (cache_control fields must be preserved).
      Returns tuple of (modifiedJSON, needsTransformation)
      */
     private func processThinkingParameter(jsonString: String) -> (String, Bool)? {
@@ -405,25 +377,18 @@ class ThinkingProxy {
                 cleanModel = String(model[..<thinkingRange.lowerBound])
             }
 
-            // --- Surgical string replacement: swap model name in original JSON ---
-            // This preserves key ordering and all other fields exactly as-is
-            var result = jsonString
-
-            // Replace model name (escape for JSON string matching)
-            let escapedModel = model.replacingOccurrences(of: "\"", with: "\\\"")
-            let escapedClean = cleanModel.replacingOccurrences(of: "\"", with: "\\\"")
-            result = result.replacingOccurrences(of: "\"\(escapedModel)\"", with: "\"\(escapedClean)\"")
+            // Surgical string replacement: swap model name preserving JSON structure
+            var result = jsonString.replacingOccurrences(of: "\"\(model)\"", with: "\"\(cleanModel)\"")
 
             if let budget = Int(budgetString), budget > 0 {
                 let modelCap = Config.hardTokenCap(for: cleanModel)
                 let effectiveBudget = min(budget, modelCap - 1)
                 if effectiveBudget != budget {
-                    NSLog("[ThinkingProxy] Adjusted thinking budget from \(budget) to \(effectiveBudget) to stay within limits (cap: \(modelCap))")
+                    NSLog("[ThinkingProxy] Adjusted thinking budget from \(budget) to \(effectiveBudget) (cap: \(modelCap))")
                 }
 
                 // Build thinking parameter JSON
-                let adaptiveModels = ["opus-4-6", "opus-4-7", "sonnet-4-6", "sonnet-4-7"]
-                let isAdaptiveModel = adaptiveModels.contains(where: { cleanModel.contains($0) })
+                let isAdaptiveModel = Config.isAdaptiveModel(cleanModel)
                 let thinkingJson: String
                 if isAdaptiveModel {
                     thinkingJson = "{\"type\":\"adaptive\"}"
@@ -432,20 +397,18 @@ class ThinkingProxy {
                     thinkingJson = "{\"type\":\"enabled\",\"budget_tokens\":\(effectiveBudget)}"
                 }
 
-                // Inject thinking parameter and adjust max_tokens via surgical insertion
-                // Insert "thinking":... right after the "model":"..." field
-                let modelField = "\"\(escapedClean)\""
-                if let modelRange = result.range(of: modelField) {
-                    let afterModel = modelRange.upperBound
-                    // Find the comma after the model value
-                    let remaining = result[afterModel...]
-                    if let commaIdx = remaining.firstIndex(of: ",") {
-                        let insertPoint = result.index(after: commaIdx)
-                        result.insert(contentsOf: "\"thinking\":\(thinkingJson),", at: insertPoint)
-                    }
+                // Inject thinking field after model field
+                result = injectJSONField(in: result, afterKey: "model", fieldName: "thinking", fieldValue: thinkingJson)
+
+                // For adaptive models, inject output_config.effort
+                if isAdaptiveModel {
+                    let effort = effortLevel ?? (cleanModel.contains("opus-4-6") ? "max" : "high")
+                    result = injectJSONField(in: result, afterKey: "thinking", fieldName: "output_config",
+                                             fieldValue: "{\"effort\":\"\(effort)\"}")
+                    ThinkingProxy.fileLog("INJECTED effort: \(effort) for model \(cleanModel)")
                 }
 
-                // Adjust max_tokens if needed
+                // Ensure max token limits exceed the thinking budget
                 let tokenHeadroom = max(Config.minimumHeadroom, Int(Double(effectiveBudget) * Config.headroomRatio))
                 let desiredMaxTokens = effectiveBudget + tokenHeadroom
                 var requiredMaxTokens = min(desiredMaxTokens, modelCap)
@@ -453,15 +416,12 @@ class ThinkingProxy {
                     requiredMaxTokens = min(effectiveBudget + 1, modelCap)
                 }
 
-                // Surgically update max_tokens or max_output_tokens if they're too low
-                result = adjustMaxTokens(in: result, field: "max_tokens", minimum: requiredMaxTokens, budget: effectiveBudget)
-                result = adjustMaxTokens(in: result, field: "max_output_tokens", minimum: requiredMaxTokens, budget: effectiveBudget)
+                result = replaceJSONIntField(in: result, key: "max_tokens",
+                                             oldValue: json["max_tokens"] as? Int, minimum: requiredMaxTokens, budget: effectiveBudget)
+                result = replaceJSONIntField(in: result, key: "max_output_tokens",
+                                             oldValue: json["max_output_tokens"] as? Int, minimum: requiredMaxTokens, budget: effectiveBudget)
 
-                if let effort = effortLevel {
-                    NSLog("[ThinkingProxy] Effort level '\(effort)' noted for model '\(cleanModel)'")
-                }
-
-                NSLog("[ThinkingProxy] Transformed model '\(model)' → '\(cleanModel)' with thinking budget \(effectiveBudget)\(effortLevel.map { ", effort: \($0)" } ?? "")")
+                NSLog("[ThinkingProxy] Transformed '\(model)' → '\(cleanModel)' with budget \(effectiveBudget)\(effortLevel.map { ", effort: \($0)" } ?? "")")
             } else {
                 NSLog("[ThinkingProxy] Stripped invalid thinking suffix from '\(model)' → '\(cleanModel)' (no thinking)")
             }
@@ -475,20 +435,37 @@ class ThinkingProxy {
         return (jsonString, false)  // No transformation needed
     }
 
-    /// Surgically adjust a numeric JSON field value if it's too low, preserving all other content
-    private func adjustMaxTokens(in jsonString: String, field: String, minimum: Int, budget: Int) -> String {
-        // Match "field_name": NUMBER pattern
-        let pattern = "\"\(field)\"\\s*:\\s*(\\d+)"
+    // MARK: - Surgical JSON string helpers
+    // These use regex to modify specific fields in-place, preserving the original JSON structure
+    // and key ordering. This is critical because JSONSerialization.data() reorders keys
+    // alphabetically, which breaks Anthropic's prompt cache matching.
+
+    /// Injects a new JSON field after a given key's value in the JSON string.
+    private func injectJSONField(in json: String, afterKey: String, fieldName: String, fieldValue: String) -> String {
+        let escapedKey = NSRegularExpression.escapedPattern(for: afterKey)
+        let valuePattern = "(?:\"(?:[^\"\\\\]|\\\\.)*\"|\\-?\\d+(?:\\.\\d+)?|\\{[^}]*\\}|\\[[^\\]]*\\]|true|false|null)"
+        let pattern = "\"\(escapedKey)\"\\s*:\\s*\(valuePattern)"
         guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: jsonString, range: NSRange(jsonString.startIndex..., in: jsonString)),
-              let valueRange = Range(match.range(at: 1), in: jsonString),
-              let currentValue = Int(jsonString[valueRange]),
-              currentValue <= budget else {
-            return jsonString
+              let match = regex.firstMatch(in: json, range: NSRange(json.startIndex..., in: json)) else {
+            NSLog("[ThinkingProxy] Warning: Could not find key '\(afterKey)' for field injection")
+            return json
         }
-        var result = jsonString
-        result.replaceSubrange(valueRange, with: String(minimum))
+        let insertOffset = match.range.location + match.range.length
+        let insertIndex = json.index(json.startIndex, offsetBy: insertOffset)
+        var result = json
+        result.insert(contentsOf: ",\"\(fieldName)\":\(fieldValue)", at: insertIndex)
         return result
+    }
+
+    /// Replaces a numeric JSON field value in-place if it's below the required minimum.
+    private func replaceJSONIntField(in json: String, key: String, oldValue: Int?, minimum: Int, budget: Int) -> String {
+        guard let current = oldValue, current <= budget else { return json }
+        let escapedKey = NSRegularExpression.escapedPattern(for: key)
+        let pattern = "\"\(escapedKey)\"(\\s*:\\s*)\(current)\\b"
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return json }
+        let range = NSRange(json.startIndex..., in: json)
+        return regex.stringByReplacingMatches(in: json, range: range,
+                                              withTemplate: "\"\(key)\"$1\(minimum)")
     }
     
     /**

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -268,10 +268,12 @@ class ThinkingProxy {
                 modifiedBody = result.0
                 thinkingEnabled = result.1
             }
-            // Strip cache_control fields that cause 400 errors via the OAuth route
-            if let stripped = stripCacheControl(from: modifiedBody) {
-                modifiedBody = stripped
-            }
+            // NOTE: Stripping cache_control fields breaks Claude's prompt caching feature,
+            // causing excessive token usage in long-running conversations.
+            // Disabled to restore prompt caching and reduce usage.
+            // if let stripped = stripCacheControl(from: modifiedBody) {
+            //     modifiedBody = stripped
+            // }
         }
         
         // Route Claude requests through Vercel AI Gateway when configured

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -33,11 +33,23 @@ class ThinkingProxy {
     var vercelConfig = VercelGatewayConfig(enabled: false, apiKey: "")
     
     private enum Config {
-        static let hardTokenCap = 32000
+        static let defaultHardTokenCap = 32_000     // Opus 4.5, Sonnet 4.5, and older
+        static let extendedHardTokenCap = 128_000   // Opus 4.6+, Sonnet 4.6+ (128K output)
         static let minimumHeadroom = 1024
         static let headroomRatio = 0.1
         static let vercelGatewayHost = "ai-gateway.vercel.sh"
         static let anthropicVersion = "2023-06-01"
+
+        /// Models that support extended output (128K) and adaptive thinking
+        private static let extendedModels = ["opus-4-6", "opus-4-7", "sonnet-4-6", "sonnet-4-7"]
+
+        /// Returns the max output token cap for a given (cleaned) model name.
+        static func hardTokenCap(for model: String) -> Int {
+            if extendedModels.contains(where: { model.contains($0) }) {
+                return extendedHardTokenCap
+            }
+            return defaultHardTokenCap
+        }
     }
     
     /**
@@ -347,110 +359,136 @@ class ThinkingProxy {
      Returns tuple of (modifiedJSON, needsTransformation)
      */
     private func processThinkingParameter(jsonString: String) -> (String, Bool)? {
+        // Parse JSON only to read values — we'll do surgical string replacements to preserve key order
+        // (JSONSerialization.data reorders keys, which breaks Anthropic's prompt cache matching)
         guard let jsonData = jsonString.data(using: .utf8),
-              var json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+              let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
               let model = json["model"] as? String else {
             return nil
         }
-        
+
         // Only process Claude models (including gemini-claude variants)
         guard model.starts(with: "claude-") || model.starts(with: "gemini-claude-") else {
             return (jsonString, false)  // Not Claude, pass through
         }
-        
-        // Check for thinking suffix pattern: -thinking-NUMBER
+
+        // Check for thinking suffix pattern: -thinking-NUMBER or -thinking-NUMBER-EFFORT
+        // where EFFORT is one of: low, medium, high, max
         let thinkingPrefix = "-thinking-"
         if let thinkingRange = model.range(of: thinkingPrefix, options: .backwards),
            thinkingRange.upperBound < model.endIndex {
-            
-            // Extract the number after "-thinking-"
-            let budgetString = String(model[thinkingRange.upperBound...])
-            
-            // For gemini-claude-* models, preserve "-thinking" and only strip the number
-            // e.g. gemini-claude-opus-4-5-thinking-10000 -> gemini-claude-opus-4-5-thinking
-            // For claude-* models, strip the entire suffix
-            // e.g. claude-opus-4-5-20251101-thinking-10000 -> claude-opus-4-5-20251101
+
+            // Extract everything after "-thinking-" (e.g. "128000" or "128000-max")
+            let suffixString = String(model[thinkingRange.upperBound...])
+
+            // Parse optional effort level from suffix (e.g. "128000-max" → budget="128000", effort="max")
+            let validEfforts = ["low", "medium", "high", "max"]
+            let budgetString: String
+            var effortLevel: String? = nil
+            if let lastDash = suffixString.lastIndex(of: "-") {
+                let candidate = String(suffixString[suffixString.index(after: lastDash)...])
+                if validEfforts.contains(candidate) {
+                    budgetString = String(suffixString[..<lastDash])
+                    effortLevel = candidate
+                } else {
+                    budgetString = suffixString
+                }
+            } else {
+                budgetString = suffixString
+            }
+
+            // Determine clean model name
             let cleanModel: String
             if model.starts(with: "gemini-claude-") {
-                cleanModel = String(model[..<thinkingRange.upperBound].dropLast(1))  // Keep "-thinking", drop trailing "-"
+                cleanModel = String(model[..<thinkingRange.upperBound].dropLast(1))
             } else {
                 cleanModel = String(model[..<thinkingRange.lowerBound])
             }
-            json["model"] = cleanModel
-            
-            // Only add thinking parameter if it's a valid integer
+
+            // --- Surgical string replacement: swap model name in original JSON ---
+            // This preserves key ordering and all other fields exactly as-is
+            var result = jsonString
+
+            // Replace model name (escape for JSON string matching)
+            let escapedModel = model.replacingOccurrences(of: "\"", with: "\\\"")
+            let escapedClean = cleanModel.replacingOccurrences(of: "\"", with: "\\\"")
+            result = result.replacingOccurrences(of: "\"\(escapedModel)\"", with: "\"\(escapedClean)\"")
+
             if let budget = Int(budgetString), budget > 0 {
-                let effectiveBudget = min(budget, Config.hardTokenCap - 1)
+                let modelCap = Config.hardTokenCap(for: cleanModel)
+                let effectiveBudget = min(budget, modelCap - 1)
                 if effectiveBudget != budget {
-                    NSLog("[ThinkingProxy] Adjusted thinking budget from \(budget) to \(effectiveBudget) to stay within limits")
+                    NSLog("[ThinkingProxy] Adjusted thinking budget from \(budget) to \(effectiveBudget) to stay within limits (cap: \(modelCap))")
                 }
 
-                // Claude Opus 4.6+ requires adaptive thinking; older models use enabled+budget_tokens
-                let isAdaptiveModel = cleanModel.contains("opus-4-6") || cleanModel.contains("opus-4-7")
+                // Build thinking parameter JSON
+                let adaptiveModels = ["opus-4-6", "opus-4-7", "sonnet-4-6", "sonnet-4-7"]
+                let isAdaptiveModel = adaptiveModels.contains(where: { cleanModel.contains($0) })
+                let thinkingJson: String
                 if isAdaptiveModel {
-                    json["thinking"] = ["type": "adaptive"]
-                    NSLog("[ThinkingProxy] Using adaptive thinking for model '\(cleanModel)'")
+                    thinkingJson = "{\"type\":\"adaptive\"}"
+                    NSLog("[ThinkingProxy] Using adaptive thinking for model '\(cleanModel)' (budget \(effectiveBudget) used as max_tokens floor)")
                 } else {
-                    json["thinking"] = [
-                        "type": "enabled",
-                        "budget_tokens": effectiveBudget
-                    ]
+                    thinkingJson = "{\"type\":\"enabled\",\"budget_tokens\":\(effectiveBudget)}"
                 }
-                
-                // Ensure max token limits are greater than the thinking budget
-                // Claude requires: max_output_tokens (or legacy max_tokens) > thinking.budget_tokens
-                // (only relevant for non-adaptive models, but safe to set for all)
+
+                // Inject thinking parameter and adjust max_tokens via surgical insertion
+                // Insert "thinking":... right after the "model":"..." field
+                let modelField = "\"\(escapedClean)\""
+                if let modelRange = result.range(of: modelField) {
+                    let afterModel = modelRange.upperBound
+                    // Find the comma after the model value
+                    let remaining = result[afterModel...]
+                    if let commaIdx = remaining.firstIndex(of: ",") {
+                        let insertPoint = result.index(after: commaIdx)
+                        result.insert(contentsOf: "\"thinking\":\(thinkingJson),", at: insertPoint)
+                    }
+                }
+
+                // Adjust max_tokens if needed
                 let tokenHeadroom = max(Config.minimumHeadroom, Int(Double(effectiveBudget) * Config.headroomRatio))
                 let desiredMaxTokens = effectiveBudget + tokenHeadroom
-                var requiredMaxTokens = min(desiredMaxTokens, Config.hardTokenCap)
+                var requiredMaxTokens = min(desiredMaxTokens, modelCap)
                 if requiredMaxTokens <= effectiveBudget {
-                    requiredMaxTokens = min(effectiveBudget + 1, Config.hardTokenCap)
+                    requiredMaxTokens = min(effectiveBudget + 1, modelCap)
                 }
-                
-                let hasMaxOutputTokensField = json.keys.contains("max_output_tokens")
-                var adjusted = false
-                
-                if let currentMaxTokens = json["max_tokens"] as? Int {
-                    if currentMaxTokens <= effectiveBudget {
-                        json["max_tokens"] = requiredMaxTokens
-                    }
-                    adjusted = true
+
+                // Surgically update max_tokens or max_output_tokens if they're too low
+                result = adjustMaxTokens(in: result, field: "max_tokens", minimum: requiredMaxTokens, budget: effectiveBudget)
+                result = adjustMaxTokens(in: result, field: "max_output_tokens", minimum: requiredMaxTokens, budget: effectiveBudget)
+
+                if let effort = effortLevel {
+                    NSLog("[ThinkingProxy] Effort level '\(effort)' noted for model '\(cleanModel)'")
                 }
-                
-                if let currentMaxOutputTokens = json["max_output_tokens"] as? Int {
-                    if currentMaxOutputTokens <= effectiveBudget {
-                        json["max_output_tokens"] = requiredMaxTokens
-                    }
-                    adjusted = true
-                }
-                
-                if !adjusted {
-                    if hasMaxOutputTokensField {
-                        json["max_output_tokens"] = requiredMaxTokens
-                    } else {
-                        json["max_tokens"] = requiredMaxTokens
-                    }
-                }
-                
-                NSLog("[ThinkingProxy] Transformed model '\(model)' → '\(cleanModel)' with thinking budget \(effectiveBudget)")
+
+                NSLog("[ThinkingProxy] Transformed model '\(model)' → '\(cleanModel)' with thinking budget \(effectiveBudget)\(effortLevel.map { ", effort: \($0)" } ?? "")")
             } else {
-                // Invalid number - just strip suffix and use vanilla model
                 NSLog("[ThinkingProxy] Stripped invalid thinking suffix from '\(model)' → '\(cleanModel)' (no thinking)")
             }
-            
-            // Convert back to JSON
-            if let modifiedData = try? JSONSerialization.data(withJSONObject: json),
-               let modifiedString = String(data: modifiedData, encoding: .utf8) {
-                return (modifiedString, true)
-            }
+
+            return (result, true)
         } else if model.hasSuffix("-thinking") || model.contains("-thinking(") {
-            // Model ends with -thinking or uses -thinking(budget) syntax (e.g. gemini-claude-opus-4-5-thinking, gemini-claude-opus-4-5-thinking(32768))
-            // Enable beta header but don't modify body - let backend handle thinking budget
             NSLog("[ThinkingProxy] Detected thinking model '\(model)' - enabling beta header, passing through to backend")
             return (jsonString, true)
         }
-        
+
         return (jsonString, false)  // No transformation needed
+    }
+
+    /// Surgically adjust a numeric JSON field value if it's too low, preserving all other content
+    private func adjustMaxTokens(in jsonString: String, field: String, minimum: Int, budget: Int) -> String {
+        // Match "field_name": NUMBER pattern
+        let pattern = "\"\(field)\"\\s*:\\s*(\\d+)"
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: jsonString, range: NSRange(jsonString.startIndex..., in: jsonString)),
+              let valueRange = Range(match.range(at: 1), in: jsonString),
+              let currentValue = Int(jsonString[valueRange]),
+              currentValue <= budget else {
+            return jsonString
+        }
+        var result = jsonString
+        result.replaceSubrange(valueRange, with: String(minimum))
+        return result
     }
     
     /**


### PR DESCRIPTION
## Summary

Builds on the same cache fix as #294 (thanks @quocanh261997!) but adds full Opus 4.6 / Sonnet 4.6 support and some additional changes needed for the latest Claude API.

- **Fix prompt cache invalidation**: Remove `stripCacheControl()` and replace JSONSerialization roundtrip with surgical string operations that preserve key ordering and `cache_control` fields
- **Opus 4.6 / Sonnet 4.6 support**: Dynamic 128K output token cap for 4.6+ models (vs 32K for older), adaptive thinking (`{"type":"adaptive"}`) instead of budget-based
- **Effort level injection**: New `output_config.effort` parameter for adaptive models — defaults to `"max"` for Opus 4.6, `"high"` for Sonnet 4.6. Configurable via model suffix (e.g. `claude-opus-4-6-thinking-128000-medium`)
- **Clean helpers**: Regex-based `injectJSONField()` and `replaceJSONIntField()` instead of inline comma-hunting string manipulation
- **Docs**: Recommended `settings.json` model entry for peak Opus 4.6 performance, updated FACTORY_SETUP.md with 4.6 presets

Closes #292

## Test plan

- [ ] Verify prompt caching works (cache hit rate should return to ~70-80%)
- [ ] Test `claude-opus-4-6-thinking-128000` — should get adaptive thinking + effort max
- [ ] Test `claude-sonnet-4-6-thinking-64000` — should get adaptive thinking + effort high
- [ ] Test `claude-opus-4-5-20251101-thinking-10000` — should still get budget-based thinking (no effort param)
- [ ] Test effort override: `claude-opus-4-6-thinking-128000-medium` — should inject effort medium
- [ ] Verify older models (Sonnet 4.5, etc.) still work with 32K cap