### PR TITLE
Allow bundling a custom CLIProxyAPIPlus binary for local testing

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -60,6 +60,24 @@ Double-click `VibeProxy.app` - it will launch immediately with no warnings! ✅
    - Create `VibeProxy.app`
    - Sign it with your Developer ID (if available)
 
+#### Testing a custom CLIProxyAPIPlus build
+
+If you want VibeProxy to use a locally built `CLIProxyAPIPlus` binary instead of the committed bundled binary:
+
+1. Build your `CLIProxyAPIPlus` fork:
+   ```bash
+   cd /path/to/CLIProxyAPIPlus
+   go build -o /tmp/cli-proxy-api-plus ./cmd/server
+   ```
+
+2. Bundle that binary into VibeProxy:
+   ```bash
+   cd /path/to/vibeproxy
+   CLI_PROXY_API_PLUS_PATH=/tmp/cli-proxy-api-plus ./create-app-bundle.sh
+   ```
+
+This lets you validate a local `CLIProxyAPIPlus` patch inside the VibeProxy app before it is released upstream.
+
 3. **Install**
    ```bash
    # Move to Applications folder

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Built on [CLIProxyAPIPlus](https://github.com/router-for-me/CLIProxyAPIPlus), it
 
 Want to build it yourself? See [**INSTALLATION.md**](INSTALLATION.md) for detailed build instructions.
 
+To test a custom `CLIProxyAPIPlus` build inside VibeProxy, build your forked binary and run:
+
+```bash
+CLI_PROXY_API_PLUS_PATH=/path/to/cli-proxy-api-plus ./create-app-bundle.sh
+```
+
+That overrides the committed bundled `cli-proxy-api-plus` binary for the generated app bundle only.
+
 ## Usage
 
 ### First Launch

--- a/create-app-bundle.sh
+++ b/create-app-bundle.sh
@@ -16,6 +16,7 @@ APP_NAME="VibeProxy"
 BUNDLE_ID="com.cliproxyapi.menubar"
 BUILD_DIR="$SRC_DIR/.build/release"
 APP_DIR="$PROJECT_DIR/$APP_NAME.app"
+CLI_PROXY_API_PLUS_PATH="${CLI_PROXY_API_PLUS_PATH:-}"
 
 # Build the Swift executable first
 echo -e "${BLUE}Building Swift executable (release)...${NC}"
@@ -62,6 +63,17 @@ if [ -d "$SRC_DIR/Sources/Resources" ]; then
             fi
         fi
     done
+fi
+
+if [ -n "$CLI_PROXY_API_PLUS_PATH" ]; then
+    echo -e "${BLUE}Overriding bundled cli-proxy-api-plus from: ${CLI_PROXY_API_PLUS_PATH}${NC}"
+    if [ ! -f "$CLI_PROXY_API_PLUS_PATH" ]; then
+        echo -e "${YELLOW}⚠️ ERROR: CLI_PROXY_API_PLUS_PATH does not exist: ${CLI_PROXY_API_PLUS_PATH}${NC}"
+        exit 1
+    fi
+
+    cp "$CLI_PROXY_API_PLUS_PATH" "$APP_DIR/Contents/Resources/cli-proxy-api-plus"
+    chmod +x "$APP_DIR/Contents/Resources/cli-proxy-api-plus"
 fi
 
 # Verify critical files were copied


### PR DESCRIPTION
## Summary
- add a `CLI_PROXY_API_PLUS_PATH` override in `create-app-bundle.sh` so local builds can bundle a custom `cli-proxy-api-plus` binary
- document the flow for building a local `CLIProxyAPIPlus` fork and bundling it into VibeProxy for validation
- keep the default behavior unchanged when the override is not set

## Why
I opened router-for-me/CLIProxyAPIPlus#463 to fix Codex-vs-openai-compat provider selection for `gpt-5-codex` in Amp/VibeProxy-style flows. This VibeProxy change makes it easy to validate that patched binary inside the macOS app before the upstream CLIProxyAPIPlus release picks it up.

## Testing
- build `CLIProxyAPIPlus` locally with `go build -o /tmp/cli-proxy-api-plus ./cmd/server`
- run `CLI_PROXY_API_PLUS_PATH=/tmp/cli-proxy-api-plus ./create-app-bundle.sh` in VibeProxy
