### PR TITLE
Fix OpenAI SSE relaying for Droid custom models

### DIFF
--- a/src/Sources/ResponsesSSEFramer.swift
+++ b/src/Sources/ResponsesSSEFramer.swift
@@ -1,0 +1,435 @@
+import Foundation
+
+final class ResponsesSSEFramer {
+    private var pending = Data()
+
+    func write(_ chunk: Data) -> [Data] {
+        guard !chunk.isEmpty else { return [] }
+
+        if Self.needsLineBreak(pending: pending, chunk: chunk) {
+            pending.append(0x0A)
+        }
+        pending.append(chunk)
+
+        var output: [Data] = []
+        while let frameLength = Self.frameLength(in: pending) {
+            let frame = Data(pending.prefix(frameLength))
+            if Self.needsMoreData(frame) {
+                guard Self.collapseIncompleteEventFrame(in: &pending, frameLength: frameLength) else {
+                    break
+                }
+                continue
+            }
+
+            output.append(Self.normalizedChunk(frame))
+            pending.removeFirst(frameLength)
+        }
+
+        if Self.trimmed(pending).isEmpty {
+            pending.removeAll(keepingCapacity: true)
+            return output
+        }
+
+        if Self.canEmitWithoutDelimiter(pending) {
+            output.append(Self.normalizedChunk(pending))
+            pending.removeAll(keepingCapacity: true)
+        }
+
+        return output
+    }
+
+    func flush() -> [Data] {
+        guard !pending.isEmpty else { return [] }
+
+        defer { pending.removeAll(keepingCapacity: true) }
+
+        let trimmedPending = Self.trimmed(pending)
+        guard !trimmedPending.isEmpty, Self.canEmitWithoutDelimiter(pending) else {
+            return []
+        }
+
+        return [Self.normalizedChunk(pending)]
+    }
+
+    private static func normalizedChunk(_ chunk: Data) -> Data {
+        if chunk.hasDataSuffix(Data("\n\n".utf8)) || chunk.hasDataSuffix(Data("\r\n\r\n".utf8)) {
+            return chunk
+        }
+
+        var result = chunk
+        if chunk.hasDataSuffix(Data("\r\n".utf8)) {
+            result.append(contentsOf: "\r\n".utf8)
+        } else if chunk.hasDataSuffix(Data("\n".utf8)) {
+            result.append(contentsOf: "\n".utf8)
+        } else {
+            result.append(contentsOf: "\n\n".utf8)
+        }
+        return result
+    }
+
+    private static func frameLength(in chunk: Data) -> Int? {
+        guard !chunk.isEmpty else { return nil }
+
+        let lfRange = chunk.range(of: Data("\n\n".utf8))
+        let crlfRange = chunk.range(of: Data("\r\n\r\n".utf8))
+
+        switch (lfRange, crlfRange) {
+        case (nil, nil):
+            return nil
+        case (nil, let crlf?):
+            return chunk.distance(from: chunk.startIndex, to: crlf.upperBound)
+        case (let lf?, nil):
+            return chunk.distance(from: chunk.startIndex, to: lf.upperBound)
+        case (let lf?, let crlf?):
+            let selectedRange = lf.lowerBound < crlf.lowerBound ? lf : crlf
+            return chunk.distance(from: chunk.startIndex, to: selectedRange.upperBound)
+        }
+    }
+
+    private static func needsMoreData(_ chunk: Data) -> Bool {
+        let trimmedChunk = trimmed(chunk)
+        guard !trimmedChunk.isEmpty else { return false }
+        return hasField(trimmedChunk, prefix: "event:") && !hasField(trimmedChunk, prefix: "data:")
+    }
+
+    private static func collapseIncompleteEventFrame(in data: inout Data, frameLength: Int) -> Bool {
+        let crlfDelimiter = Data("\r\n\r\n".utf8)
+        if Data(data.prefix(frameLength)).hasDataSuffix(crlfDelimiter) {
+            let collapseStart = data.index(data.startIndex, offsetBy: frameLength - 2)
+            let collapseEnd = data.index(data.startIndex, offsetBy: frameLength)
+            data.removeSubrange(collapseStart..<collapseEnd)
+            return true
+        }
+
+        let lfDelimiter = Data("\n\n".utf8)
+        if Data(data.prefix(frameLength)).hasDataSuffix(lfDelimiter) {
+            let collapseStart = data.index(data.startIndex, offsetBy: frameLength - 1)
+            let collapseEnd = data.index(data.startIndex, offsetBy: frameLength)
+            data.removeSubrange(collapseStart..<collapseEnd)
+            return true
+        }
+
+        return false
+    }
+
+    private static func hasField(_ chunk: Data, prefix: String) -> Bool {
+        for line in lines(of: chunk) {
+            let trimmedLine = trimmed(line)
+            if trimmedLine.starts(with: Data(prefix.utf8)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func canEmitWithoutDelimiter(_ chunk: Data) -> Bool {
+        let trimmedChunk = trimmed(chunk)
+        guard !trimmedChunk.isEmpty else { return false }
+        guard !needsMoreData(trimmedChunk), hasField(trimmedChunk, prefix: "data:") else {
+            return false
+        }
+        return dataLinesAreValid(trimmedChunk)
+    }
+
+    private static func dataLinesAreValid(_ chunk: Data) -> Bool {
+        for line in lines(of: chunk) {
+            let trimmedLine = trimmed(line)
+            guard !trimmedLine.isEmpty else { continue }
+            let prefix = Data("data:".utf8)
+            guard trimmedLine.starts(with: prefix) else { continue }
+
+            let payload = trimmed(Data(trimmedLine.dropFirst(prefix.count)))
+            if payload.isEmpty || payload == Data("[DONE]".utf8) {
+                continue
+            }
+            if (try? JSONSerialization.jsonObject(with: payload)) == nil {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func needsLineBreak(pending: Data, chunk: Data) -> Bool {
+        guard !pending.isEmpty, !chunk.isEmpty else { return false }
+        guard !pending.hasDataSuffix(Data("\n".utf8)), !pending.hasDataSuffix(Data("\r".utf8)) else {
+            return false
+        }
+        guard chunk.first != 0x0A, chunk.first != 0x0D else {
+            return false
+        }
+
+        let trimmedChunk = chunk.drop(while: { $0 == 0x20 || $0 == 0x09 })
+        guard !trimmedChunk.isEmpty else { return false }
+
+        let prefixes = ["data:", "event:", "id:", "retry:", ":"]
+        return prefixes.contains { trimmedChunk.starts(with: Data($0.utf8)) }
+    }
+
+    private static func lines(of chunk: Data) -> [Data] {
+        guard !chunk.isEmpty else { return [] }
+
+        var lines: [Data] = []
+        var startIndex = chunk.startIndex
+
+        for index in chunk.indices where chunk[index] == 0x0A {
+            lines.append(Data(chunk[startIndex..<index]))
+            startIndex = chunk.index(after: index)
+        }
+
+        if startIndex < chunk.endIndex {
+            lines.append(Data(chunk[startIndex..<chunk.endIndex]))
+        }
+
+        return lines
+    }
+
+    private static func trimmed(_ data: Data) -> Data {
+        var lower = data.startIndex
+        var upper = data.endIndex
+
+        while lower < upper, isWhitespace(data[lower]) {
+            lower = data.index(after: lower)
+        }
+
+        while lower < upper {
+            let previous = data.index(before: upper)
+            guard isWhitespace(data[previous]) else { break }
+            upper = previous
+        }
+
+        return Data(data[lower..<upper])
+    }
+
+    private static func isWhitespace(_ byte: UInt8) -> Bool {
+        byte == 0x20 || byte == 0x09 || byte == 0x0A || byte == 0x0D
+    }
+}
+
+final class HTTPChunkedDecoder {
+    private var pending = Data()
+    private var expectedChunkLength: Int?
+    private var finished = false
+
+    func decode(_ chunk: Data, isComplete: Bool) -> [Data] {
+        guard !finished else { return [] }
+
+        if !chunk.isEmpty {
+            pending.append(chunk)
+        }
+
+        var output: [Data] = []
+
+        while true {
+            if let expectedChunkLength {
+                if expectedChunkLength == 0 {
+                    guard consumeTrailersIfAvailable() else { break }
+                    finished = true
+                    break
+                }
+
+                let requiredLength = expectedChunkLength + 2
+                guard pending.count >= requiredLength else { break }
+
+                output.append(Data(pending.prefix(expectedChunkLength)))
+                pending.removeFirst(expectedChunkLength)
+
+                guard pending.hasDataPrefix(Data("\r\n".utf8)) else {
+                    break
+                }
+                pending.removeFirst(2)
+                self.expectedChunkLength = nil
+                continue
+            }
+
+            guard let lineLength = Self.lineLength(in: pending) else { break }
+
+            let sizeLine = Data(pending.prefix(lineLength - 2))
+            pending.removeFirst(lineLength)
+
+            guard let size = Self.parseChunkLength(from: sizeLine) else {
+                break
+            }
+
+            expectedChunkLength = size
+        }
+
+        if isComplete {
+            pending.removeAll(keepingCapacity: true)
+            expectedChunkLength = nil
+            finished = true
+        }
+
+        return output
+    }
+
+    private func consumeTrailersIfAvailable() -> Bool {
+        if pending.hasDataPrefix(Data("\r\n".utf8)) {
+            pending.removeFirst(2)
+            return true
+        }
+
+        guard let trailerLength = Self.delimiterLength(in: pending, delimiter: Data("\r\n\r\n".utf8)) else {
+            return false
+        }
+
+        pending.removeFirst(trailerLength)
+        return true
+    }
+
+    private static func parseChunkLength(from data: Data) -> Int? {
+        guard let line = String(data: data, encoding: .utf8) else { return nil }
+        let sizeToken = line.split(separator: ";", maxSplits: 1, omittingEmptySubsequences: false).first ?? ""
+        return Int(sizeToken.trimmingCharacters(in: .whitespacesAndNewlines), radix: 16)
+    }
+
+    private static func lineLength(in data: Data) -> Int? {
+        delimiterLength(in: data, delimiter: Data("\r\n".utf8))
+    }
+
+    private static func delimiterLength(in data: Data, delimiter: Data) -> Int? {
+        guard let range = data.range(of: delimiter) else { return nil }
+        return data.distance(from: data.startIndex, to: range.upperBound)
+    }
+}
+
+final class HTTPResponseRelay {
+    private enum BodyMode {
+        case passthrough
+        case responsesSSE
+        case chunkedResponsesSSE
+    }
+
+    private var headerBuffer = Data()
+    private var headersParsed = false
+    private var bodyMode: BodyMode = .passthrough
+    private let chunkedDecoder = HTTPChunkedDecoder()
+    private let responsesFramer = ResponsesSSEFramer()
+
+    init(requestPath: String) {
+        _ = requestPath
+    }
+
+    func process(_ data: Data, isComplete: Bool) -> [Data] {
+        if headersParsed {
+            return processBody(data, isComplete: isComplete)
+        }
+
+        if !data.isEmpty {
+            headerBuffer.append(data)
+        }
+
+        guard let headerRange = headerBuffer.range(of: Data("\r\n\r\n".utf8)) else {
+            if isComplete {
+                let buffered = headerBuffer
+                headerBuffer.removeAll(keepingCapacity: true)
+                headersParsed = true
+                return buffered.isEmpty ? [] : [buffered]
+            }
+            return []
+        }
+
+        let headerEnd = headerBuffer.distance(from: headerBuffer.startIndex, to: headerRange.upperBound)
+        let (headerData, resolvedBodyMode) = Self.rewriteHeaders(Data(headerBuffer.prefix(headerEnd)))
+        let bodyData = Data(headerBuffer.dropFirst(headerEnd))
+        headerBuffer.removeAll(keepingCapacity: true)
+        headersParsed = true
+        bodyMode = resolvedBodyMode
+
+        var output = [headerData]
+        output.append(contentsOf: processBody(bodyData, isComplete: isComplete))
+        return output
+    }
+
+    private func processBody(_ data: Data, isComplete: Bool) -> [Data] {
+        switch bodyMode {
+        case .passthrough:
+            return data.isEmpty ? [] : [data]
+        case .responsesSSE:
+            var output: [Data] = []
+            if !data.isEmpty {
+                output.append(contentsOf: responsesFramer.write(data))
+            }
+            if isComplete {
+                output.append(contentsOf: responsesFramer.flush())
+            }
+            return output
+        case .chunkedResponsesSSE:
+            var output: [Data] = []
+            for decodedChunk in chunkedDecoder.decode(data, isComplete: isComplete) {
+                output.append(contentsOf: responsesFramer.write(decodedChunk))
+            }
+            if isComplete {
+                output.append(contentsOf: responsesFramer.flush())
+            }
+            return output
+        }
+    }
+
+    private static func rewriteHeaders(_ headerData: Data) -> (Data, BodyMode) {
+        guard let headerString = String(data: headerData, encoding: .utf8) else {
+            return (headerData, .passthrough)
+        }
+
+        let rawLines = headerString.components(separatedBy: "\r\n")
+        guard let statusLine = rawLines.first else {
+            return (headerData, .passthrough)
+        }
+
+        let hasEventStream = rawLines.contains {
+            $0.lowercased().hasPrefix("content-type:") && $0.lowercased().contains("text/event-stream")
+        }
+        let hasChunkedTransferEncoding = rawLines.contains {
+            $0.lowercased().hasPrefix("transfer-encoding:") && $0.lowercased().contains("chunked")
+        }
+
+        guard hasEventStream else {
+            return (headerData, .passthrough)
+        }
+
+        var rewrittenLines = [statusLine]
+        var insertedConnectionClose = false
+
+        for line in rawLines.dropFirst() {
+            if line.isEmpty { continue }
+
+            let lowercasedLine = line.lowercased()
+            if lowercasedLine.hasPrefix("transfer-encoding:") || lowercasedLine.hasPrefix("content-length:") {
+                continue
+            }
+            if lowercasedLine.hasPrefix("connection:") {
+                rewrittenLines.append("Connection: close")
+                insertedConnectionClose = true
+                continue
+            }
+
+            rewrittenLines.append(line)
+        }
+
+        if !insertedConnectionClose {
+            rewrittenLines.append("Connection: close")
+        }
+
+        let rewrittenHeaderData = Data((rewrittenLines + ["", ""]).joined(separator: "\r\n").utf8)
+        let bodyMode: BodyMode = hasChunkedTransferEncoding ? .chunkedResponsesSSE : .responsesSSE
+        return (rewrittenHeaderData, bodyMode)
+    }
+}
+
+private extension Data {
+    func hasDataSuffix(_ expectedSuffix: Data) -> Bool {
+        guard count >= expectedSuffix.count else { return false }
+        return self.suffix(expectedSuffix.count).elementsEqual(expectedSuffix)
+    }
+
+    func hasDataPrefix(_ expectedPrefix: Data) -> Bool {
+        guard count >= expectedPrefix.count else { return false }
+        return self.prefix(expectedPrefix.count).elementsEqual(expectedPrefix)
+    }
+
+    var isEventStream: Bool {
+        guard let headerString = String(data: self, encoding: .utf8) else { return false }
+        return headerString
+            .components(separatedBy: "\r\n")
+            .contains { $0.lowercased().hasPrefix("content-type:") && $0.lowercased().contains("text/event-stream") }
+    }
+}

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -674,7 +674,7 @@ class ThinkingProxy {
                             targetConnection.cancel()
                             originalConnection.cancel()
                         } else {
-                            self.receiveResponse(from: targetConnection, originalConnection: originalConnection)
+                            self.receiveResponse(from: targetConnection, originalConnection: originalConnection, requestPath: path)
                         }
                     }))
                 }
@@ -773,7 +773,7 @@ class ThinkingProxy {
                                                                  method: method, path: path, version: version, 
                                                                  headers: headers, body: body)
                             } else {
-                                self.receiveResponse(from: targetConnection, originalConnection: originalConnection)
+                                self.receiveResponse(from: targetConnection, originalConnection: originalConnection, requestPath: path)
                             }
                         }
                     }))
@@ -835,22 +835,15 @@ class ThinkingProxy {
                     }
                 }
                 
-                // Not a 404 or already has /api/, forward response as-is
-                originalConnection.send(content: data, completion: .contentProcessed({ sendError in
-                    if let sendError = sendError {
-                        NSLog("[ThinkingProxy] Send error: \(sendError)")
-                    }
-                    
-                    if isComplete {
-                        targetConnection.cancel()
-                        originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
-                            originalConnection.cancel()
-                        }))
-                    } else {
-                        // Continue streaming
-                        self.streamNextChunk(from: targetConnection, to: originalConnection)
-                    }
-                }))
+                // Not a 404 or already has /api/, continue with normal response relay.
+                let relay = HTTPResponseRelay(requestPath: path)
+                self.forwardRelayedResponseChunks(
+                    relay.process(data, isComplete: isComplete),
+                    targetConnection: targetConnection,
+                    originalConnection: originalConnection,
+                    isComplete: isComplete,
+                    relay: relay
+                )
             } else if isComplete {
                 targetConnection.cancel()
                 originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
@@ -864,15 +857,15 @@ class ThinkingProxy {
      Receives response from CLIProxyAPI
      Starts the streaming loop for response data
      */
-    private func receiveResponse(from targetConnection: NWConnection, originalConnection: NWConnection) {
+    private func receiveResponse(from targetConnection: NWConnection, originalConnection: NWConnection, requestPath: String) {
         // Start the streaming loop
-        streamNextChunk(from: targetConnection, to: originalConnection)
+        streamNextChunk(from: targetConnection, to: originalConnection, relay: HTTPResponseRelay(requestPath: requestPath))
     }
     
     /**
      Streams response chunks iteratively (uses async scheduling instead of recursion to avoid stack buildup)
      */
-    private func streamNextChunk(from targetConnection: NWConnection, to originalConnection: NWConnection) {
+    private func streamNextChunk(from targetConnection: NWConnection, to originalConnection: NWConnection, relay: HTTPResponseRelay) {
         targetConnection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
             guard let self = self else { return }
             
@@ -884,31 +877,75 @@ class ThinkingProxy {
             }
             
             if let data = data, !data.isEmpty {
-                // Forward response chunk to original client
-                originalConnection.send(content: data, completion: .contentProcessed({ sendError in
-                    if let sendError = sendError {
-                        NSLog("[ThinkingProxy] Send response error: \(sendError)")
-                    }
-                    
-                    if isComplete {
-                        targetConnection.cancel()
-                        // Always close client connection - no keep-alive/pipelining support
-                        originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
-                            originalConnection.cancel()
-                        }))
-                    } else {
-                        // Schedule next iteration of the streaming loop
-                        self.streamNextChunk(from: targetConnection, to: originalConnection)
-                    }
-                }))
+                self.forwardRelayedResponseChunks(
+                    relay.process(data, isComplete: isComplete),
+                    targetConnection: targetConnection,
+                    originalConnection: originalConnection,
+                    isComplete: isComplete,
+                    relay: relay
+                )
             } else if isComplete {
+                self.forwardRelayedResponseChunks(
+                    relay.process(Data(), isComplete: true),
+                    targetConnection: targetConnection,
+                    originalConnection: originalConnection,
+                    isComplete: true,
+                    relay: relay
+                )
+            }
+        }
+    }
+
+    private func forwardRelayedResponseChunks(
+        _ chunks: [Data],
+        targetConnection: NWConnection,
+        originalConnection: NWConnection,
+        isComplete: Bool,
+        relay: HTTPResponseRelay
+    ) {
+        sendResponseChunks(chunks, to: originalConnection) { [weak self] sendError in
+            guard let self = self else { return }
+
+            if let sendError = sendError {
+                NSLog("[ThinkingProxy] Send response error: \(sendError)")
                 targetConnection.cancel()
-                // Always close client connection - no keep-alive/pipelining support
+                originalConnection.cancel()
+                return
+            }
+
+            if isComplete {
+                targetConnection.cancel()
                 originalConnection.send(content: nil, isComplete: true, completion: .contentProcessed({ _ in
                     originalConnection.cancel()
                 }))
+            } else {
+                self.streamNextChunk(from: targetConnection, to: originalConnection, relay: relay)
             }
         }
+    }
+
+    private func sendResponseChunks(_ chunks: [Data], to connection: NWConnection, completion: @escaping (NWError?) -> Void) {
+        guard !chunks.isEmpty else {
+            completion(nil)
+            return
+        }
+
+        func sendChunk(at index: Int) {
+            guard index < chunks.count else {
+                completion(nil)
+                return
+            }
+
+            connection.send(content: chunks[index], completion: .contentProcessed({ error in
+                if let error = error {
+                    completion(error)
+                    return
+                }
+                sendChunk(at: index + 1)
+            }))
+        }
+
+        sendChunk(at: 0)
     }
     
     /**

--- a/src/Tests/ResponsesSSEFramerTests.swift
+++ b/src/Tests/ResponsesSSEFramerTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import CLIProxyMenuBar
+
+final class ResponsesSSEFramerTests: XCTestCase {
+    func testFramesPartialResponsesEventAcrossChunks() throws {
+        let framer = ResponsesSSEFramer()
+
+        let firstOutput = framer.write(Data("event: response.output_text.delta".utf8))
+        XCTAssertTrue(firstOutput.isEmpty)
+
+        let secondOutput = framer.write(
+            Data("\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n".utf8)
+        )
+
+        XCTAssertEqual(secondOutput.count, 1)
+        XCTAssertEqual(
+            String(data: secondOutput[0], encoding: .utf8),
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n"
+        )
+    }
+
+    func testRelayReframesResponsesSSEAfterHeaders() throws {
+        let relay = HTTPResponseRelay(requestPath: "/v1/responses")
+
+        let initial = Data((
+            "HTTP/1.1 200 OK\r\n" +
+            "Content-Type: text/event-stream\r\n" +
+            "Connection: close\r\n\r\n" +
+            "event: response.output_text.delta"
+        ).utf8)
+
+        let firstOutput = relay.process(initial, isComplete: false)
+        XCTAssertEqual(firstOutput.count, 1)
+        XCTAssertEqual(
+            String(data: firstOutput[0], encoding: .utf8),
+            "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n"
+        )
+
+        let secondOutput = relay.process(
+            Data("\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"done\"}\n\n".utf8),
+            isComplete: false
+        )
+
+        XCTAssertEqual(secondOutput.count, 1)
+        XCTAssertEqual(
+            String(data: secondOutput[0], encoding: .utf8),
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"done\"}\n\n"
+        )
+    }
+
+    func testRelayPassthroughForNonResponsesRequest() throws {
+        let relay = HTTPResponseRelay(requestPath: "/v1/chat/completions")
+        let raw = Data("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{}".utf8)
+
+        let output = relay.process(raw, isComplete: true)
+
+        XCTAssertEqual(output, [raw])
+    }
+
+    func testFramerHandlesSlicedDataWithoutIndexTrap() throws {
+        let framer = ResponsesSSEFramer()
+        let base = Data("prefix\ndata: {\"type\":\"response.created\"}\n\n".utf8)
+        let sliced = Data(base.dropFirst("prefix\n".count))
+
+        let output = framer.write(sliced)
+
+        XCTAssertEqual(output.count, 1)
+        XCTAssertEqual(
+            String(data: output[0], encoding: .utf8),
+            "data: {\"type\":\"response.created\"}\n\n"
+        )
+    }
+
+    func testRelayDecodesChunkedEventStreamResponses() throws {
+        let relay = HTTPResponseRelay(requestPath: "/v1/chat/completions")
+        let raw = Data((
+            "HTTP/1.1 200 OK\r\n" +
+            "Content-Type: text/event-stream\r\n" +
+            "Transfer-Encoding: chunked\r\n" +
+            "Connection: keep-alive\r\n\r\n" +
+            "26\r\n" +
+            "data: {\"type\":\"response.created\"}\n\n\r\n" +
+            "0\r\n\r\n"
+        ).utf8)
+
+        let output = relay.process(raw, isComplete: true)
+
+        XCTAssertEqual(output.count, 2)
+        XCTAssertEqual(
+            String(data: output[0], encoding: .utf8),
+            "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n"
+        )
+        XCTAssertEqual(
+            String(data: output[1], encoding: .utf8),
+            "data: {\"type\":\"response.created\"}\n\n"
+        )
+    }
+
+    func testFramerMergesEventAndDataAcrossDecodedChunks() throws {
+        let framer = ResponsesSSEFramer()
+
+        XCTAssertTrue(framer.write(Data("event: response.created\n\n".utf8)).isEmpty)
+
+        let output = framer.write(Data("data: {\"type\":\"response.created\"}\n\n".utf8))
+
+        XCTAssertEqual(output.count, 1)
+        XCTAssertEqual(
+            String(data: output[0], encoding: .utf8),
+            "event: response.created\ndata: {\"type\":\"response.created\"}\n\n"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- normalize OpenAI SSE responses before forwarding them to local clients like Droid
- decode chunked event streams and rewrite headers so the proxy emits a clean close-delimited stream
- add regression coverage for fragmented `event:` / `data:` frames and Data-slice edge cases

## Root Cause
Droid custom OpenAI models could fail through VibeProxy with OpenAI OAuth because VibeProxy forwarded backend OpenAI Responses streams too literally. In practice the client could receive partial SSE fragments such as `event: response.created` without the matching `data:` payload in the same message boundary, which caused Droid to fail with `JSON Parse error: Unexpected EOF`.

A second issue showed up while fixing this: some backend responses arrived with `Transfer-Encoding: chunked`, so the proxy needed to decode chunked bodies before reframing SSE. There were also Data index handling edge cases that could trap when working with sliced buffers.

## Changelog
- add `ResponsesSSEFramer` to buffer and merge fragmented OpenAI SSE frames
- add `HTTPChunkedDecoder` to decode chunked event-stream bodies before reframing
- add `HTTPResponseRelay` to rewrite SSE response headers and normalize response forwarding
- route proxied responses in `ThinkingProxy` through the relay instead of forwarding raw chunks
- keep `/v1/chat/completions` and `/v1/responses` streaming behavior consistent for Droid and similar clients
- add regression tests for split event/data frames, chunked event streams, and sliced Data buffer handling

## Implementation Details
### New relay path
- `ThinkingProxy.receiveResponse` now carries the request path into a response relay
- `streamNextChunk` forwards backend chunks through `HTTPResponseRelay`
- `forwardRelayedResponseChunks` and `sendResponseChunks` serialize rewritten chunks back to the client

### SSE framing
- hold incomplete `event:` frames until the matching `data:` line arrives
- preserve complete SSE message boundaries with normalized trailing delimiters
- avoid emitting standalone event-only messages that break OpenAI SDK parsers

### Chunked decoding
- detect `Transfer-Encoding: chunked` on event-stream responses
- decode HTTP chunk bodies before SSE processing
- rewrite response headers to remove chunked transfer encoding and return `Connection: close`

### Safety / regression handling
- fix Data index math so sliced buffers do not trap while removing ranges
- keep non-event-stream responses on the passthrough path

## Testing
- `swift build`
- manual `curl` verification for `/v1/chat/completions` streaming through VibeProxy
- manual `curl` verification for `/v1/responses` streaming through VibeProxy
- direct socket-level verification that `event:` and `data:` were emitted together after the fix
- `droid exec --model custom:gpt-5.4(xhigh) ...` against the patched app, verified end-to-end success

## Manual Verification Notes
Before the fix, Droid reproducibly failed on the proxy path with split SSE fragments and `Unexpected EOF` parsing errors.

After the fix:
- `/v1/chat/completions` streams returned clean SSE data through the proxy
- `/v1/responses` streams returned combined `event:` + `data:` frames instead of standalone event fragments
- Droid completed successfully through the installed VibeProxy app using the custom OpenAI model path