### PR TITLE
Add GLM-5.x models as default Z.AI models for API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Built on [CLIProxyAPIPlus](https://github.com/router-for-me/CLIProxyAPIPlus), it
 > [!TIP]
 > 📣 **NEW: Vercel AI Gateway Integration!**<br>Route your Claude requests through [Vercel's officially sanctioned AI Gateway](https://vercel.com/docs/ai-gateway) for safer access to your Claude Max subscription. No more worrying about account risks from using OAuth tokens directly!
 >
-> **Latest models supported:** Gemini 3 Pro (via Antigravity), GPT-5.1 / GPT-5.1 Codex, Claude Sonnet 4.5 / Opus 4.5 with extended thinking, GitHub Copilot, and Z.AI GLM-4.7! 🚀 
+> **Latest models supported:** Gemini 3 Pro (via Antigravity), GPT-5.1 / GPT-5.1 Codex, Claude Sonnet 4.5 / Opus 4.5 with extended thinking, GitHub Copilot, and Z.AI GLM-5.1 / GLM-5 / GLM-4.7! 🚀 
 > 
 > **Setup Guides:**
 > - [Factory CLI Setup →](FACTORY_SETUP.md) - Use Factory Droids with your AI subscriptions

--- a/src/Sources/ConfigComposer.swift
+++ b/src/Sources/ConfigComposer.swift
@@ -408,6 +408,10 @@ enum ConfigComposer {
 
     private static func defaultZAIModels() -> [[String: String]] {
         [
+            ["name": "glm-5.1", "alias": "glm-5.1"],
+            ["name": "glm-5v-turbo", "alias": "glm-5v-turbo"],
+            ["name": "glm-5", "alias": "glm-5"],
+            ["name": "glm-5-turbo", "alias": "glm-5-turbo"],
             ["name": "glm-4.7", "alias": "glm-4.7"],
             ["name": "glm-4-plus", "alias": "glm-4-plus"],
             ["name": "glm-4-air", "alias": "glm-4-air"],

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -692,7 +692,7 @@ struct SettingsView: View {
                         iconName: "icon-zai.png",
                         accounts: authManager.accounts(for: .zai),
                         isAuthenticating: authenticatingService == .zai,
-                        helpText: "Z.AI GLM provides access to GLM-4.7 and other models via API key. Get your key at https://z.ai/manage-apikey/apikey-list",
+                        helpText: "Z.AI GLM provides access to GLM-5.1, GLM-5, GLM-4.7, and other models via API key. Get your key at https://z.ai/manage-apikey/apikey-list",
                         isEnabled: serverManager.isProviderEnabled("zai"),
                         isToggleLocked: serverManager.isProviderToggleLocked("zai"),
                         toggleHelpText: serverManager.providerConfigLockReason("zai"),
@@ -983,7 +983,7 @@ struct SettingsView: View {
         case .antigravity:
             return "🌐 Browser opened for Antigravity authentication.\n\nPlease complete the login in your browser."
         case .zai:
-            return "✓ Z.AI API key added successfully.\n\nYou can now use GLM models through the proxy."
+            return "✓ Z.AI API key added successfully.\n\nYou can now use GLM models (including GLM-5.1, GLM-5, GLM-5v-turbo) through the proxy."
         }
     }
     


### PR DESCRIPTION
This pull request expands support for Z.AI GLM models by adding the latest versions (GLM-5.1, GLM-5, and GLM-5v-turbo) throughout the app, and updates user-facing documentation and help texts to reflect these new options.

**Z.AI GLM model support enhancements:**

* Added support for new models (`glm-5.1`, `glm-5`, `glm-5v-turbo`, `glm-5-turbo`) in the Z.AI model configuration list in `ConfigComposer.swift`.

**User interface and documentation updates:**

* Updated the help text in the Z.AI GLM section of `SettingsView.swift` to mention support for GLM-5.1, GLM-5, and GLM-4.7.
* Improved the success message shown after adding a Z.AI API key to indicate that GLM-5.1, GLM-5, and GLM-5v-turbo are now available.
* Updated the README to list GLM-5.1, GLM-5, and GLM-4.7 as supported models in the summary of latest model support.