### PR TITLE
Add Kimi authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <a href="https://github.com/automazeio/vibeproxy"><img alt="Star this repo" src="https://img.shields.io/github/stars/automazeio/vibeproxy.svg?style=social&amp;label=Star%20this%20repo&amp;maxAge=60" style="max-width: 100%;"></a></p>
 </p>
 
-**Stop paying twice for AI.** VibeProxy is a beautiful native macOS menu bar app that lets you use your existing Claude Code, ChatGPT, **Gemini**, **Qwen**, **Antigravity**, and **Z.AI GLM** subscriptions with powerful AI coding tools like **[Factory Droids](https://app.factory.ai/r/FM8BJHFQ)** – no separate API keys required.
+**Stop paying twice for AI.** VibeProxy is a beautiful native macOS menu bar app that lets you use your existing Claude Code, ChatGPT, **Gemini**, **Kimi**, **Qwen**, **Antigravity**, and **Z.AI GLM** subscriptions with powerful AI coding tools like **[Factory Droids](https://app.factory.ai/r/FM8BJHFQ)**.
 
 Built on [CLIProxyAPIPlus](https://github.com/router-for-me/CLIProxyAPIPlus), it handles OAuth authentication, token management, and API routing automatically. One click to authenticate, zero friction to code.
 
@@ -24,7 +24,7 @@ Built on [CLIProxyAPIPlus](https://github.com/router-for-me/CLIProxyAPIPlus), it
 > [!TIP]
 > 📣 **NEW: Vercel AI Gateway Integration!**<br>Route your Claude requests through [Vercel's officially sanctioned AI Gateway](https://vercel.com/docs/ai-gateway) for safer access to your Claude Max subscription. No more worrying about account risks from using OAuth tokens directly!
 >
-> **Latest models supported:** Gemini 3 Pro (via Antigravity), GPT-5.1 / GPT-5.1 Codex, Claude Sonnet 4.5 / Opus 4.5 with extended thinking, GitHub Copilot, and Z.AI GLM-4.7! 🚀 
+> **Latest models supported:** Gemini 3 Pro (via Antigravity), GPT-5.1 / GPT-5.1 Codex, Claude Sonnet 4.5 / Opus 4.5 with extended thinking, GitHub Copilot, Z.AI GLM-4.7, and Kimi! 🚀 
 > 
 > **Setup Guides:**
 > - [Factory CLI Setup →](FACTORY_SETUP.md) - Use Factory Droids with your AI subscriptions
@@ -36,7 +36,7 @@ Built on [CLIProxyAPIPlus](https://github.com/router-for-me/CLIProxyAPIPlus), it
 
 - 🎯 **Native macOS Experience** - Clean, native SwiftUI interface that feels right at home on macOS
 - 🚀 **One-Click Server Management** - Start/stop the proxy server from your menu bar
-- 🔐 **Easy Authentication** - Authenticate with Codex, Claude Code, Gemini, Qwen, Antigravity (OAuth), and Z.AI GLM (API key) directly from the app
+- 🔐 **Easy Authentication** - Authenticate with Codex, Claude Code, Gemini, Kimi, Qwen, and Antigravity (OAuth), plus Z.AI GLM (API key) directly from the app
 - 🛡️ **Vercel AI Gateway** - Route Claude requests through [Vercel's AI Gateway](https://vercel.com/docs/ai-gateway) for safer access to your Claude Max subscription without risking your account from direct OAuth token usage
 - 👥 **Multi-Account Support** - Connect multiple accounts per provider with automatic round-robin distribution and failover when rate-limited
 - 🎚️ **Provider Priority** - Enable/disable providers to control which models are available (instant hot reload)
@@ -72,15 +72,20 @@ Want to build it yourself? See [**INSTALLATION.md**](INSTALLATION.md) for detail
 1. Launch VibeProxy - you'll see a menu bar icon
 2. Click the icon and select "Open Settings"
 3. The server will start automatically
-4. Click "Connect" for Claude Code, Codex, Gemini, Qwen, or Antigravity to authenticate, or "Add Account" for Z.AI GLM to enter your API key
+4. Click "Connect" for Claude Code, Codex, Gemini, Kimi, Qwen, or Antigravity to authenticate, or "Add Account" for Z.AI GLM
 
 ### Authentication
 
-When you click "Connect":
+When you click "Connect" for an OAuth provider:
 1. Your browser opens with the OAuth page
 2. Complete the authentication in the browser
 3. VibeProxy automatically detects your credentials
 4. Status updates to show you're connected
+
+When you click "Add Account" for Z.AI GLM:
+1. Paste your provider API key
+2. VibeProxy stores it in `~/.cli-proxy-api/`
+3. The provider becomes available through the proxy immediately
 
 ### Server Management
 

--- a/src/Sources/AuthStatus.swift
+++ b/src/Sources/AuthStatus.swift
@@ -5,6 +5,7 @@ enum ServiceType: String, CaseIterable {
     case codex
     case copilot = "github-copilot"
     case gemini
+    case kimi
     case qwen
     case antigravity
     case zai
@@ -15,6 +16,7 @@ enum ServiceType: String, CaseIterable {
         case .codex: return "Codex"
         case .copilot: return "GitHub Copilot"
         case .gemini: return "Gemini"
+        case .kimi: return "Kimi"
         case .qwen: return "Qwen"
         case .antigravity: return "Antigravity"
         case .zai: return "Z.AI GLM"

--- a/src/Sources/ProviderCatalog.swift
+++ b/src/Sources/ProviderCatalog.swift
@@ -8,6 +8,7 @@ enum ProviderCatalog {
         "claude": "claude",
         "codex": "codex",
         "gemini": "gemini-cli",
+        "kimi": "kimi",
         "github-copilot": "github-copilot",
         "antigravity": "antigravity",
         "qwen": "qwen"

--- a/src/Sources/ServerManager.swift
+++ b/src/Sources/ServerManager.swift
@@ -379,6 +379,8 @@ class ServerManager: ObservableObject {
             authProcess.arguments = ["--config", configPath, "-github-copilot-login"]
         case .geminiLogin:
             authProcess.arguments = ["--config", configPath, "-login"]
+        case .kimiLogin:
+            authProcess.arguments = ["--config", configPath, "-kimi-login"]
         case .qwenLogin(let email):
             authProcess.arguments = ["--config", configPath, "-qwen-login"]
             qwenEmail = email
@@ -1159,6 +1161,7 @@ enum AuthCommand: Equatable {
     case codexLogin
     case copilotLogin
     case geminiLogin
+    case kimiLogin
     case qwenLogin(email: String)
     case antigravityLogin
 }

--- a/src/Sources/ServiceType+ConnectionAction.swift
+++ b/src/Sources/ServiceType+ConnectionAction.swift
@@ -1,0 +1,28 @@
+enum ServiceConnectionAction: Equatable {
+    case authCommand(AuthCommand)
+    case promptForQwenEmail
+    case promptForZAIAPIKey
+}
+
+extension ServiceType {
+    var connectionAction: ServiceConnectionAction {
+        switch self {
+        case .claude:
+            return .authCommand(.claudeLogin)
+        case .codex:
+            return .authCommand(.codexLogin)
+        case .copilot:
+            return .authCommand(.copilotLogin)
+        case .gemini:
+            return .authCommand(.geminiLogin)
+        case .kimi:
+            return .authCommand(.kimiLogin)
+        case .qwen:
+            return .promptForQwenEmail
+        case .antigravity:
+            return .authCommand(.antigravityLogin)
+        case .zai:
+            return .promptForZAIAPIKey
+        }
+    }
+}

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -113,6 +113,7 @@ struct VercelGatewayControls: View {
 struct ServiceRow<ExtraContent: View>: View {
     let serviceType: ServiceType
     let iconName: String
+    let iconSystemName: String?
     let accounts: [AuthAccount]
     let isAuthenticating: Bool
     let helpText: String?
@@ -159,6 +160,10 @@ struct ServiceRow<ExtraContent: View>: View {
                     Image(nsImage: nsImage)
                         .resizable()
                         .renderingMode(.template)
+                        .frame(width: 20, height: 20)
+                        .opacity(isEnabled ? 1.0 : 0.4)
+                } else if let iconSystemName {
+                    Image(systemName: iconSystemName)
                         .frame(width: 20, height: 20)
                         .opacity(isEnabled ? 1.0 : 0.4)
                 }
@@ -580,6 +585,7 @@ struct SettingsView: View {
                     ServiceRow(
                         serviceType: .antigravity,
                         iconName: "icon-antigravity.png",
+                        iconSystemName: nil,
                         accounts: authManager.accounts(for: .antigravity),
                         isAuthenticating: authenticatingService == .antigravity,
                         helpText: "Antigravity provides OAuth-based access to various AI models including Gemini and Claude. One login gives you access to multiple AI services.",
@@ -598,6 +604,7 @@ struct SettingsView: View {
                     ServiceRow(
                         serviceType: .claude,
                         iconName: "icon-claude.png",
+                        iconSystemName: nil,
                         accounts: authManager.accounts(for: .claude),
                         isAuthenticating: authenticatingService == .claude,
                         helpText: nil,
@@ -618,6 +625,7 @@ struct SettingsView: View {
                     ServiceRow(
                         serviceType: .codex,
                         iconName: "icon-codex.png",
+                        iconSystemName: nil,
                         accounts: authManager.accounts(for: .codex),
                         isAuthenticating: authenticatingService == .codex,
                         helpText: nil,
@@ -636,6 +644,7 @@ struct SettingsView: View {
                     ServiceRow(
                         serviceType: .gemini,
                         iconName: "icon-gemini.png",
+                        iconSystemName: nil,
                         accounts: authManager.accounts(for: .gemini),
                         isAuthenticating: authenticatingService == .gemini,
                         helpText: "⚠️ Note: If you're an existing Gemini user with multiple projects, authentication will use your default project. Set your desired project as default in Google AI Studio before connecting.",
@@ -652,8 +661,28 @@ struct SettingsView: View {
                     ) { EmptyView() }
 
                     ServiceRow(
+                        serviceType: .kimi,
+                        iconName: "icon-kimi.png",
+                        iconSystemName: "moon.stars.fill",
+                        accounts: authManager.accounts(for: .kimi),
+                        isAuthenticating: authenticatingService == .kimi,
+                        helpText: "Kimi uses browser-based account authentication so you can route requests through your Kimi subscription instead of an API key.",
+                        isEnabled: serverManager.isProviderEnabled("kimi"),
+                        isToggleLocked: serverManager.isProviderToggleLocked("kimi"),
+                        toggleHelpText: serverManager.providerConfigLockReason("kimi"),
+                        disabledReasonText: serverManager.providerConfigLockReason("kimi"),
+                        customTitle: nil,
+                        onConnect: { connectService(.kimi) },
+                        onDisconnect: { account in disconnectAccount(account) },
+                        onToggleDisabled: { account in toggleAccountDisabled(account) },
+                        onToggleEnabled: { enabled in serverManager.setProviderEnabled("kimi", enabled: enabled) },
+                        onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
+                    ) { EmptyView() }
+
+                    ServiceRow(
                         serviceType: .copilot,
                         iconName: "icon-copilot.png",
+                        iconSystemName: nil,
                         accounts: authManager.accounts(for: .copilot),
                         isAuthenticating: authenticatingService == .copilot,
                         helpText: "GitHub Copilot provides access to Claude, GPT, Gemini and other models via your Copilot subscription.",
@@ -672,6 +701,7 @@ struct SettingsView: View {
                     ServiceRow(
                         serviceType: .qwen,
                         iconName: "icon-qwen.png",
+                        iconSystemName: nil,
                         accounts: authManager.accounts(for: .qwen),
                         isAuthenticating: authenticatingService == .qwen,
                         helpText: nil,
@@ -690,6 +720,7 @@ struct SettingsView: View {
                     ServiceRow(
                         serviceType: .zai,
                         iconName: "icon-zai.png",
+                        iconSystemName: nil,
                         accounts: authManager.accounts(for: .zai),
                         isAuthenticating: authenticatingService == .zai,
                         helpText: "Z.AI GLM provides access to GLM-4.7 and other models via API key. Get your key at https://z.ai/manage-apikey/apikey-list",
@@ -931,16 +962,13 @@ struct SettingsView: View {
         NSLog("[SettingsView] Starting %@ authentication", serviceType.displayName)
         
         let command: AuthCommand
-        switch serviceType {
-        case .claude: command = .claudeLogin
-        case .codex: command = .codexLogin
-        case .copilot: command = .copilotLogin
-        case .gemini: command = .geminiLogin
-        case .qwen:
+        switch serviceType.connectionAction {
+        case .authCommand(let authCommand):
+            command = authCommand
+        case .promptForQwenEmail:
             authenticatingService = nil
             return // handled separately with email prompt
-        case .antigravity: command = .antigravityLogin
-        case .zai:
+        case .promptForZAIAPIKey:
             authenticatingService = nil
             return // handled separately with API key prompt
         }
@@ -978,6 +1006,8 @@ struct SettingsView: View {
             return "🌐 GitHub Copilot authentication started!\n\nPlease visit github.com/login/device and enter the code shown.\n\nThe app will automatically detect your credentials."
         case .gemini:
             return "🌐 Browser opened for Gemini authentication.\n\nPlease complete the login in your browser.\n\n⚠️ Note: If you have multiple projects, the default project will be used."
+        case .kimi:
+            return "🌐 Browser opened for Kimi authentication.\n\nPlease complete the login in your browser.\n\nThe app will automatically detect your Kimi account."
         case .qwen:
             return "🌐 Browser opened for Qwen authentication.\n\nPlease complete the login in your browser."
         case .antigravity:

--- a/src/Tests/ProviderWiringTests.swift
+++ b/src/Tests/ProviderWiringTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import CLIProxyMenuBar
+
+final class ProviderWiringTests: XCTestCase {
+    func testConnectionActionMatchesExistingProviderFlows() {
+        XCTAssertEqual(ServiceType.claude.connectionAction, .authCommand(.claudeLogin))
+        XCTAssertEqual(ServiceType.codex.connectionAction, .authCommand(.codexLogin))
+        XCTAssertEqual(ServiceType.copilot.connectionAction, .authCommand(.copilotLogin))
+        XCTAssertEqual(ServiceType.gemini.connectionAction, .authCommand(.geminiLogin))
+        XCTAssertEqual(ServiceType.kimi.connectionAction, .authCommand(.kimiLogin))
+        XCTAssertEqual(ServiceType.qwen.connectionAction, .promptForQwenEmail)
+        XCTAssertEqual(ServiceType.antigravity.connectionAction, .authCommand(.antigravityLogin))
+        XCTAssertEqual(ServiceType.zai.connectionAction, .promptForZAIAPIKey)
+    }
+
+    func testKimiProviderCatalogRegistrationMatchesRuntimeProviderKey() {
+        XCTAssertEqual(ProviderCatalog.oauthProviderKeys["kimi"], "kimi")
+        XCTAssertTrue(ProviderCatalog.reservedCustomProviderKeys.contains("kimi"))
+    }
+}


### PR DESCRIPTION
## Summary
- add Kimi as a first-class OAuth provider in the macOS app so it can be enabled, authenticated, and managed alongside Claude, Codex, Copilot, Gemini, Qwen, Antigravity, and Z.AI
- wire the Kimi login flow through the bundled `cli-proxy-api-plus -kimi-login` runtime path, including service registration, provider toggles, and the post-login success copy shown in Settings
- refactor provider connection initiation so prompt-based providers keep their special handling instead of being implicitly treated like direct auth-command providers
- add provider wiring tests to lock down the routing contract for existing providers and verify that Kimi stays mapped to the runtime provider key and auth command it needs
- update the README to include Kimi in the supported provider list and first-launch setup flow while keeping the Z.AI button wording aligned with the existing UI

## User-Facing Changes
- add a new Kimi row in Settings with provider enable/disable support and browser-based authentication
- show Kimi in the supported provider and first-launch documentation alongside the other built-in providers
- keep the existing Qwen and Z.AI flows unchanged from a user perspective: Qwen still prompts for email before continuing, and Z.AI still prompts for an API key instead of launching an OAuth command

## Implementation Details
- `AuthStatus.swift` adds `ServiceType.kimi` and the display name used throughout the UI
- `ProviderCatalog.swift` registers `kimi` as a managed OAuth provider key so provider toggles and reserved-provider handling include it
- `ServerManager.swift` adds `.kimiLogin` and maps it to `cli-proxy-api-plus -kimi-login`
- `SettingsView.swift` adds the Kimi service row, help text, and success message shown after login
- `ServiceType+ConnectionAction.swift` extracts provider connection routing into a small explicit contract that can be tested independently of the SwiftUI view logic
- `ProviderWiringTests.swift` verifies both the direct auth-command providers and the prompt-based providers

## Why the `ServiceConnectionAction` refactor matters
Before this PR, `SettingsView.connectService` mixed two different behaviors in a single `switch`:
- providers that can immediately launch a CLI auth command
- providers that first need additional UI input from VibeProxy before any command can run

That distinction was already real in the app before Kimi existed:
- Qwen needs an email prompt before the login flow continues
- Z.AI needs an API key prompt instead of an OAuth/browser flow

This PR makes that contract explicit by letting each `ServiceType` resolve to one of three entry paths:
- `.authCommand(...)`
- `.promptForQwenEmail`
- `.promptForZAIAPIKey`

That is why these cases are important:
- `promptForQwenEmail` is not just a fallback; it preserves the existing Qwen-specific prompt flow and prevents it from being accidentally flattened into a generic auth command
- `promptForZAIAPIKey` does the same for Z.AI, which is intentionally not an OAuth provider in the app UI
- Kimi now cleanly fits the direct-auth path as `.authCommand(.kimiLogin)`

In practice, this makes the provider startup behavior easier to read, easier to extend, and safer to test. The new wiring tests specifically assert that Kimi maps to `.kimiLogin` while Qwen and Z.AI continue to use their dedicated prompt-based flows.

## Verification
- `cd src && swift test`
