### PR TITLE
Fix local app persistence and menu bar issues

### DIFF
--- a/src/Sources/AppDelegate.swift
+++ b/src/Sources/AppDelegate.swift
@@ -130,9 +130,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
     }
     
     func setupMenuBar() {
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        statusItem.isVisible = true
 
         if let button = statusItem.button {
+            button.imagePosition = .imageOnly
+            button.toolTip = "VibeProxy"
             if let icon = IconCatalog.shared.image(named: "icon-inactive.png", resizedTo: NSSize(width: 18, height: 18), template: true) {
                 button.image = icon
             } else {

--- a/src/Sources/ConfigComposer.swift
+++ b/src/Sources/ConfigComposer.swift
@@ -8,12 +8,30 @@ struct ConfigProviderAuthRecord: Equatable {
 
 enum ConfigComposer {
     static let uiMetadataKeys: Set<String> = ["display-name", "help-text", "icon-system"]
+    static let runtimeEditableTopLevelKeys: Set<String> = ["api-keys"]
     
     static func composeAdditiveBaseConfig(bundledRoot: [String: Any], userRoot: [String: Any]?) -> [String: Any] {
         guard let userRoot else {
             return bundledRoot
         }
         return mergeDictionary(bundledRoot, overlaidWith: userRoot)
+    }
+
+    static func preservingRuntimeEditableTopLevelKeys(
+        in root: [String: Any],
+        from runtimeRoot: [String: Any]?
+    ) -> [String: Any] {
+        guard let runtimeRoot else {
+            return root
+        }
+
+        var mergedRoot = root
+        for key in runtimeEditableTopLevelKeys where mergedRoot[key] == nil {
+            if let runtimeValue = runtimeRoot[key] {
+                mergedRoot[key] = runtimeValue
+            }
+        }
+        return mergedRoot
     }
     
     static func parseCustomProviders(

--- a/src/Sources/ServerManager.swift
+++ b/src/Sources/ServerManager.swift
@@ -739,7 +739,7 @@ class ServerManager: ObservableObject {
     private func resolveConfigPath(
         enabledProviderStates: [String: Bool]
     ) -> Result<String, ConfigResolutionFailure> {
-        guard let bundledConfigPath = bundledConfigPath() else {
+        guard bundledConfigPath() != nil else {
             return .failure(ConfigResolutionFailure(message: "Could not locate the bundled config.yaml in the app bundle."))
         }
         let baseConfigResult = loadBaseConfigRoot()
@@ -771,18 +771,7 @@ class ServerManager: ObservableObject {
                 enabledProviderStates: enabledProviderStates
             )
         }
-        let needsMergedConfig =
-            baseConfig.isUserConfig ||
-            !zaiApiKeys.isEmpty ||
-            !disabledProviders.isEmpty ||
-            !disabledCustomProviderIDs.isEmpty ||
-            !customAuthRecords.isEmpty
-        
-        guard needsMergedConfig else {
-            return .success(bundledConfigPath)
-        }
-        
-        let mergedRoot = ConfigComposer.composeRuntimeConfig(
+        var mergedRoot = ConfigComposer.composeRuntimeConfig(
             baseRoot: baseConfig.root,
             reservedCustomProviderKeys: ProviderCatalog.reservedCustomProviderKeys,
             disabledCustomProviderIDs: disabledCustomProviderIDs,
@@ -804,6 +793,14 @@ class ServerManager: ObservableObject {
         )
         
         let mergedConfigPath = authDir.appendingPathComponent(CustomProviderConstants.mergedConfigFilename)
+        if mergedRoot["api-keys"] == nil,
+           case .success(let existingRuntimeRoot) = loadYAMLDictionary(atPath: mergedConfigPath.path) {
+            mergedRoot = ConfigComposer.preservingRuntimeEditableTopLevelKeys(
+                in: mergedRoot,
+                from: existingRuntimeRoot
+            )
+        }
+
         do {
             try FileManager.default.createDirectory(at: authDir, withIntermediateDirectories: true)
             let mergedContent = try Yams.dump(object: mergedRoot)

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -209,7 +209,7 @@ struct ServiceRow<ExtraContent: View>: View {
                     if isExpanded {
                         VStack(alignment: .leading, spacing: 6) {
                             ForEach(accounts) { account in
-                                AccountRowView(account: account, removeColor: removeColor, showDisableToggle: accounts.count > 1, isLastEnabled: !account.isDisabled && enabledCount <= 1, onToggleDisabled: {
+                                AccountRowView(account: account, removeColor: removeColor, showDisableToggle: accounts.count > 1 || account.isDisabled, isLastEnabled: !account.isDisabled && enabledCount <= 1, onToggleDisabled: {
                                     onToggleDisabled(account)
                                 }) {
                                     accountToRemove = account

--- a/src/Tests/ConfigComposerTests.swift
+++ b/src/Tests/ConfigComposerTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import CLIProxyMenuBar
+
+final class ConfigComposerTests: XCTestCase {
+    func testPreservesRuntimeEditedTopLevelAPIKeysWhenBaseDoesNotDefineThem() {
+        let root: [String: Any] = ["port": 8318]
+        let runtimeRoot: [String: Any] = [
+            "api-keys": ["local-key"],
+            "port": 9000
+        ]
+
+        let result = ConfigComposer.preservingRuntimeEditableTopLevelKeys(
+            in: root,
+            from: runtimeRoot
+        )
+
+        XCTAssertEqual(result["api-keys"] as? [String], ["local-key"])
+        XCTAssertEqual(result["port"] as? Int, 8318)
+    }
+
+    func testDoesNotOverwriteExplicitTopLevelAPIKeys() {
+        let root: [String: Any] = ["api-keys": ["configured-key"]]
+        let runtimeRoot: [String: Any] = ["api-keys": ["runtime-key"]]
+
+        let result = ConfigComposer.preservingRuntimeEditableTopLevelKeys(
+            in: root,
+            from: runtimeRoot
+        )
+
+        XCTAssertEqual(result["api-keys"] as? [String], ["configured-key"])
+    }
+}


### PR DESCRIPTION
## Summary
- always pass CLIProxyAPI a user-owned runtime config instead of the bundled app config
- preserve runtime-edited top-level `api-keys` from the existing merged config
- allow re-enabling the only remaining disabled account
- use a fixed square menu bar status item to avoid clipped/off-screen placement

## Validation
- swift test --package-path src

Fixes #340.
Fixes #326.
Helps #342.