### PR TITLE
fix: add current Z.AI GLM models

### DIFF
--- a/CODEX_DESKTOP_SETUP.md
+++ b/CODEX_DESKTOP_SETUP.md
@@ -1,0 +1,57 @@
+# Codex Desktop Setup
+
+Use VibeProxy as Codex Desktop's single model provider when you want OpenAI/Codex models and Z.AI GLM models available from the same local endpoint.
+
+## Requirements
+
+- VibeProxy is running on `http://localhost:8317`
+- Codex is connected in VibeProxy
+- Z.AI GLM has an API key added in VibeProxy
+
+Verify the proxy exposes both model families:
+
+```bash
+curl http://localhost:8317/v1/models
+```
+
+You should see OpenAI/Codex models such as `gpt-5.5` and Z.AI models such as `glm-5.2`.
+
+## Codex Config
+
+Codex selects one `model_provider` for a thread. To switch between OpenAI and GLM from the Codex model picker, point Codex at VibeProxy and let VibeProxy route by model name.
+
+Add this to `~/.codex/config.toml`:
+
+```toml
+model = "gpt-5.5"
+model_provider = "vibeproxy"
+model_catalog_json = "/Users/YOU/.codex/model_catalog_vibeproxy.json"
+
+[model_providers.vibeproxy]
+name = "VibeProxy"
+base_url = "http://localhost:8317/v1"
+wire_api = "responses"
+experimental_bearer_token = "dummy-not-used"
+```
+
+## Model Picker Catalog
+
+Codex Desktop's picker is catalog-driven. If a GLM model does not appear in the picker, create a custom catalog that contains the built-in Codex models plus a `glm-5.2` entry.
+
+The catalog entry only controls display and model capabilities. Provider routing still comes from the single `model_provider = "vibeproxy"` setting above.
+
+After changing `model_catalog_json`, restart Codex Desktop so it reloads the catalog.
+
+## Smoke Tests
+
+```bash
+curl http://localhost:8317/v1/responses \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"glm-5.2","input":"Say ok.","max_output_tokens":512}'
+```
+
+Then select `glm-5.2` in Codex Desktop or start a CLI smoke test:
+
+```bash
+codex exec --model glm-5.2 "Reply with exactly: glm-ok"
+```

--- a/FACTORY_SETUP.md
+++ b/FACTORY_SETUP.md
@@ -310,6 +310,13 @@ Edit your Factory configuration file at `~/.factory/config.json` (if the file do
     },
 
     {
+      "model_display_name": "GLM-5.2",
+      "model": "glm-5.2",
+      "base_url": "http://localhost:8317/v1",
+      "api_key": "dummy-not-used",
+      "provider": "openai"
+    },
+    {
       "model_display_name": "GLM-5",
       "model": "glm-5",
       "base_url": "http://localhost:8317/v1",
@@ -434,6 +441,7 @@ Antigravity provides access to Claude models with a generous usage quota (shared
 - `qwen3-coder-flash` - Qwen3 Coder Flash (Fast coding assistant)
 
 ### Z.AI GLM Models
+- `glm-5.2` - GLM-5.2 (latest GLM model; availability may depend on your Z.AI plan)
 - `glm-5` - GLM-5 (latest GLM model; Pro availability may depend on your Z.AI plan)
 - `glm-4.7` - GLM-4.7 (stable GLM coding model)
 - `glm-4-plus` - GLM-4-Plus (Enhanced GLM model)

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ Built on [CLIProxyAPIPlus](https://github.com/router-for-me/CLIProxyAPIPlus), it
 > [!TIP]
 > 📣 **NEW: Vercel AI Gateway Integration!**<br>Route your Claude requests through [Vercel's officially sanctioned AI Gateway](https://vercel.com/docs/ai-gateway) for safer access to your Claude Max subscription. No more worrying about account risks from using OAuth tokens directly!
 >
-> **Latest models supported:** Gemini 3 Pro (via Antigravity), GPT-5.1 / GPT-5.1 Codex, Claude Sonnet 4.5 / Opus 4.5 with extended thinking, GitHub Copilot, Z.AI GLM-4.7, and Kimi! 🚀 
+> **Latest models supported:** Gemini 3 Pro (via Antigravity), GPT-5.1 / GPT-5.1 Codex, Claude Sonnet 4.5 / Opus 4.5 with extended thinking, GitHub Copilot, Z.AI GLM-5.2 / GLM-5, and Kimi! 🚀
 > 
 > **Setup Guides:**
 > - [Factory CLI Setup →](FACTORY_SETUP.md) - Use Factory Droids with your AI subscriptions
 > - [Amp CLI Setup →](AMPCODE_SETUP.md) - Use Amp CLI with fallback to your subscriptions
+> - [Codex Desktop Setup →](CODEX_DESKTOP_SETUP.md) - Use Codex Desktop with VibeProxy-routed OpenAI and GLM models
 
 ---
 

--- a/src/Sources/ConfigComposer.swift
+++ b/src/Sources/ConfigComposer.swift
@@ -426,6 +426,8 @@ enum ConfigComposer {
 
     private static func defaultZAIModels() -> [[String: String]] {
         [
+            ["name": "glm-5.2", "alias": "glm-5.2"],
+            ["name": "glm-5", "alias": "glm-5"],
             ["name": "glm-4.7", "alias": "glm-4.7"],
             ["name": "glm-4-plus", "alias": "glm-4-plus"],
             ["name": "glm-4-air", "alias": "glm-4-air"],

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -723,7 +723,7 @@ struct SettingsView: View {
                         iconSystemName: nil,
                         accounts: authManager.accounts(for: .zai),
                         isAuthenticating: authenticatingService == .zai,
-                        helpText: "Z.AI GLM provides access to GLM-4.7 and other models via API key. Get your key at https://z.ai/manage-apikey/apikey-list",
+                        helpText: "Z.AI GLM provides access to GLM-5.2, GLM-5, GLM-4.7, and other models via API key. Get your key at https://z.ai/manage-apikey/apikey-list",
                         isEnabled: serverManager.isProviderEnabled("zai"),
                         isToggleLocked: serverManager.isProviderToggleLocked("zai"),
                         toggleHelpText: serverManager.providerConfigLockReason("zai"),

--- a/src/Verification/ConfigComposerSpec.swift
+++ b/src/Verification/ConfigComposerSpec.swift
@@ -245,6 +245,12 @@ struct ConfigComposerSpec {
 
             let zai = provider(named: "zai", in: runtime)
             expectEqual(apiKeys(in: zai ?? [:]), ["zai-key-1"], "managed zai provider should be injected", recorder: recorder)
+            expectEqual(
+                modelAliases(in: zai ?? [:]),
+                ["glm-5.2", "glm-5", "glm-4.7", "glm-4-plus", "glm-4-air", "glm-4-flash"],
+                "managed zai provider should include current GLM aliases",
+                recorder: recorder
+            )
         }
 
         run("composeRuntimeConfig preserves user-authored zai models and merges inline plus managed keys", recorder: recorder) {


### PR DESCRIPTION
## Summary
- add `glm-5.2` and `glm-5` to the managed Z.AI provider defaults
- update Z.AI Settings help text and Factory docs
- add a Codex Desktop setup guide for using VibeProxy as the single provider for OpenAI/Codex and GLM model switching

## Verification
- `swift test`
- `swiftc src/Sources/ConfigComposer.swift src/Sources/ProviderCatalog.swift src/Sources/CustomProviders.swift src/Verification/ConfigComposerSpec.swift -o /tmp/vibeproxy-config-composer-spec && /tmp/vibeproxy-config-composer-spec`
- locally installed a patched VibeProxy build and verified `curl http://localhost:8317/v1/models` includes `glm-5.2`, `glm-5`, and existing OpenAI/Codex models
- verified `POST /v1/responses` with `glm-5.2` returns a completed response with final text
- verified `codex exec --model glm-5.2` routes through provider `vibeproxy` and returns the expected output

## Note
The local OpenAI/Codex smoke route reached VibeProxy correctly but the connected Codex credential was in usage-limit cooldown, so the PR validation focuses on model exposure and GLM routing.