### PR TITLE
Add MiniMax provider support

### DIFF
--- a/FACTORY_SETUP.md
+++ b/FACTORY_SETUP.md
@@ -23,6 +23,7 @@ VibeProxy manages OAuth tokens, auto-refreshes them, routes requests, and handle
 - **Google Cloud account** with Gemini API access for Gemini 2.x models (optional)
 - **GitHub Copilot** subscription for Copilot model access (optional) — gives Claude, GPT, and Gemini models via GitHub's API
 - **Z.AI API key** for GLM model access (optional) - get one at [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list)
+- **MiniMax API key** for MiniMax model access (optional) - get one at [platform.minimax.io](https://platform.minimax.io)
 - Factory CLI installed: `curl -fsSL https://app.factory.ai/cli | sh`
 
 ## Step 1: Install VibeProxy
@@ -62,6 +63,10 @@ Once VibeProxy is running:
 8. **(Optional)** Click **"Add Account"** next to Z.AI GLM
    - Enter your Z.AI API key (get one at [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list))
    - This provides access to **GLM-5**, **GLM-4.7**, and other GLM models
+   - VibeProxy will securely store your API key
+9. **(Optional)** Click **"Add Account"** next to MiniMax
+   - Enter your MiniMax API key (get one at [platform.minimax.io](https://platform.minimax.io))
+   - This provides access to **MiniMax-M3**, **MiniMax-M2.7**, **MiniMax-M2.5**, and other MiniMax models
    - VibeProxy will securely store your API key
 
 ✅ The server starts automatically and runs on port **8317**
@@ -442,6 +447,19 @@ Antigravity provides access to Claude models with a generous usage quota (shared
 
 > [!NOTE]
 > Z.AI GLM models require an API key instead of OAuth authentication. Get your API key at [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list) and add it in VibeProxy Settings → Z.AI GLM → Add Account.
+
+### MiniMax Models
+- `MiniMax-M3` - Latest MiniMax text model
+- `MiniMax-M2.7` - MiniMax M2.7 text model
+- `MiniMax-M2.7-highspeed` - Faster MiniMax M2.7 variant
+- `MiniMax-M2.5` - MiniMax M2.5 text model
+- `MiniMax-M2.5-highspeed` - Faster MiniMax M2.5 variant
+- `MiniMax-M2.1` - MiniMax M2.1 text model
+- `MiniMax-M2.1-highspeed` - Faster MiniMax M2.1 variant
+- `MiniMax-M2` - MiniMax M2 text model
+
+> [!NOTE]
+> MiniMax models require an API key instead of OAuth authentication. Get your API key at [platform.minimax.io](https://platform.minimax.io) and add it in VibeProxy Settings → MiniMax → Add Account.
 
 ### OpenAI Models
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <a href="https://github.com/automazeio/vibeproxy"><img alt="Star this repo" src="https://img.shields.io/github/stars/automazeio/vibeproxy.svg?style=social&amp;label=Star%20this%20repo&amp;maxAge=60" style="max-width: 100%;"></a></p>
 </p>
 
-**Stop paying twice for AI.** VibeProxy is a beautiful native macOS menu bar app that lets you use your existing Claude Code, ChatGPT, **Gemini**, **Kimi**, **Qwen**, **Antigravity**, and **Z.AI GLM** subscriptions with powerful AI coding tools like **[Factory Droids](https://app.factory.ai/r/FM8BJHFQ)**.
+**Stop paying twice for AI.** VibeProxy is a beautiful native macOS menu bar app that lets you use your existing Claude Code, ChatGPT, **Gemini**, **Kimi**, **Qwen**, **Antigravity**, **Z.AI GLM**, and **MiniMax** accounts or API keys with powerful AI coding tools like **[Factory Droids](https://app.factory.ai/r/FM8BJHFQ)**.
 
 Built on [CLIProxyAPIPlus](https://github.com/router-for-me/CLIProxyAPIPlus), it handles OAuth authentication, token management, and API routing automatically. One click to authenticate, zero friction to code.
 
@@ -24,7 +24,7 @@ Built on [CLIProxyAPIPlus](https://github.com/router-for-me/CLIProxyAPIPlus), it
 > [!TIP]
 > 📣 **NEW: Vercel AI Gateway Integration!**<br>Route your Claude requests through [Vercel's officially sanctioned AI Gateway](https://vercel.com/docs/ai-gateway) for safer access to your Claude Max subscription. No more worrying about account risks from using OAuth tokens directly!
 >
-> **Latest models supported:** Gemini 3 Pro (via Antigravity), GPT-5.1 / GPT-5.1 Codex, Claude Sonnet 4.5 / Opus 4.5 with extended thinking, GitHub Copilot, Z.AI GLM-4.7, and Kimi! 🚀 
+> **Latest models supported:** Gemini 3 Pro (via Antigravity), GPT-5.1 / GPT-5.1 Codex, Claude Sonnet 4.5 / Opus 4.5 with extended thinking, GitHub Copilot, Z.AI GLM-4.7, MiniMax-M3, and Kimi! 🚀
 > 
 > **Setup Guides:**
 > - [Factory CLI Setup →](FACTORY_SETUP.md) - Use Factory Droids with your AI subscriptions
@@ -36,7 +36,7 @@ Built on [CLIProxyAPIPlus](https://github.com/router-for-me/CLIProxyAPIPlus), it
 
 - 🎯 **Native macOS Experience** - Clean, native SwiftUI interface that feels right at home on macOS
 - 🚀 **One-Click Server Management** - Start/stop the proxy server from your menu bar
-- 🔐 **Easy Authentication** - Authenticate with Codex, Claude Code, Gemini, Kimi, Qwen, and Antigravity (OAuth), plus Z.AI GLM (API key) directly from the app
+- 🔐 **Easy Authentication** - Authenticate with Codex, Claude Code, Gemini, Kimi, Qwen, and Antigravity (OAuth), plus Z.AI GLM and MiniMax (API keys) directly from the app
 - 🛡️ **Vercel AI Gateway** - Route Claude requests through [Vercel's AI Gateway](https://vercel.com/docs/ai-gateway) for safer access to your Claude Max subscription without risking your account from direct OAuth token usage
 - 👥 **Multi-Account Support** - Connect multiple accounts per provider with automatic round-robin distribution and failover when rate-limited
 - 🎚️ **Provider Priority** - Enable/disable providers to control which models are available (instant hot reload)
@@ -72,7 +72,7 @@ Want to build it yourself? See [**INSTALLATION.md**](INSTALLATION.md) for detail
 1. Launch VibeProxy - you'll see a menu bar icon
 2. Click the icon and select "Open Settings"
 3. The server will start automatically
-4. Click "Connect" for Claude Code, Codex, Gemini, Kimi, Qwen, or Antigravity to authenticate, or "Add Account" for Z.AI GLM
+4. Click "Connect" for Claude Code, Codex, Gemini, Kimi, Qwen, or Antigravity to authenticate, or "Add Account" for Z.AI GLM or MiniMax
 
 ### Authentication
 
@@ -82,7 +82,7 @@ When you click "Connect" for an OAuth provider:
 3. VibeProxy automatically detects your credentials
 4. Status updates to show you're connected
 
-When you click "Add Account" for Z.AI GLM:
+When you click "Add Account" for Z.AI GLM or MiniMax:
 1. Paste your provider API key
 2. VibeProxy stores it in `~/.cli-proxy-api/`
 3. The provider becomes available through the proxy immediately

--- a/src/Sources/AuthStatus.swift
+++ b/src/Sources/AuthStatus.swift
@@ -9,6 +9,7 @@ enum ServiceType: String, CaseIterable {
     case qwen
     case antigravity
     case zai
+    case minimax
     
     var displayName: String {
         switch self {
@@ -20,6 +21,7 @@ enum ServiceType: String, CaseIterable {
         case .qwen: return "Qwen"
         case .antigravity: return "Antigravity"
         case .zai: return "Z.AI GLM"
+        case .minimax: return "MiniMax"
         }
     }
 }

--- a/src/Sources/ConfigComposer.swift
+++ b/src/Sources/ConfigComposer.swift
@@ -105,7 +105,8 @@ enum ConfigComposer {
                 seenProviderIDs.insert(providerID)
             }
 
-            if reservedProviderIDs.contains(providerID), providerID != ProviderCatalog.managedZAIProviderName {
+            if reservedProviderIDs.contains(providerID),
+               !ProviderCatalog.managedOpenAICompatibleProviderNames.contains(providerID) {
                 errors.append("Provider '\(providerID)' is reserved and cannot be declared under openai-compatibility.")
                 continue
             }
@@ -132,7 +133,7 @@ enum ConfigComposer {
                 }
             }
 
-            if providerID == ProviderCatalog.managedZAIProviderName {
+            if ProviderCatalog.managedOpenAICompatibleProviderNames.contains(providerID) {
                 continue
             }
 
@@ -151,9 +152,12 @@ enum ConfigComposer {
         disabledCustomProviderIDs: Set<String>,
         disabledOAuthProviderKeys: [String],
         zaiAPIKeys: [String],
+        miniMaxAPIKeys: [String],
         customProviderAuthRecords: [ConfigProviderAuthRecord],
         includeManagedZAIProvider: Bool,
-        managedZAIProviderName: String = "zai"
+        includeManagedMiniMaxProvider: Bool,
+        managedZAIProviderName: String = "zai",
+        managedMiniMaxProviderName: String = "minimax"
     ) -> [String: Any] {
         var mergedRoot = baseRoot
         
@@ -179,6 +183,7 @@ enum ConfigComposer {
         
         var mergedOpenAICompatibility: [[String: Any]] = []
         var managedZAIBaseEntry: [String: Any]?
+        var managedMiniMaxBaseEntry: [String: Any]?
         for entry in stringKeyedDictionaryArray(mergedRoot["openai-compatibility"]) {
             guard let providerName = normalizedProviderID(from: entry) else {
                 continue
@@ -188,6 +193,10 @@ enum ConfigComposer {
             sanitizedEntry["name"] = providerName
             if providerName == managedZAIProviderName {
                 managedZAIBaseEntry = sanitizedEntry
+                continue
+            }
+            if providerName == managedMiniMaxProviderName {
+                managedMiniMaxBaseEntry = sanitizedEntry
                 continue
             }
             
@@ -215,6 +224,16 @@ enum ConfigComposer {
             )
             if !apiKeyEntries(from: managedZAIEntry).isEmpty {
                 mergedOpenAICompatibility.append(managedZAIEntry)
+            }
+        }
+
+        if includeManagedMiniMaxProvider {
+            let managedMiniMaxEntry = makeMiniMaxProviderEntry(
+                baseEntry: managedMiniMaxBaseEntry,
+                apiKeys: miniMaxAPIKeys
+            )
+            if !apiKeyEntries(from: managedMiniMaxEntry).isEmpty {
+                mergedOpenAICompatibility.append(managedMiniMaxEntry)
             }
         }
         
@@ -408,6 +427,26 @@ enum ConfigComposer {
         return entry
     }
 
+    private static func makeMiniMaxProviderEntry(baseEntry: [String: Any]?, apiKeys: [String]) -> [String: Any] {
+        var entry = stripCustomProviderUIMetadata(from: baseEntry ?? [:])
+        entry["name"] = "minimax"
+
+        if normalizedString(entry["base-url"]) == nil {
+            entry["base-url"] = "https://api.minimax.io/v1"
+        }
+
+        let inlineEntries = apiKeyEntries(from: entry)
+        entry["api-key-entries"] = deduplicatedAPIKeyEntries(
+            inlineEntries + apiKeys.map { ["api-key": $0] }
+        )
+
+        if stringKeyedDictionaryArray(entry["models"]).isEmpty {
+            entry["models"] = defaultMiniMaxModels()
+        }
+
+        return entry
+    }
+
     private static func normalizedProviderID(from entry: [String: Any]) -> String? {
         normalizedString(entry["name"])
     }
@@ -430,6 +469,19 @@ enum ConfigComposer {
             ["name": "glm-4-plus", "alias": "glm-4-plus"],
             ["name": "glm-4-air", "alias": "glm-4-air"],
             ["name": "glm-4-flash", "alias": "glm-4-flash"]
+        ]
+    }
+
+    private static func defaultMiniMaxModels() -> [[String: String]] {
+        [
+            ["name": "MiniMax-M3", "alias": "MiniMax-M3"],
+            ["name": "MiniMax-M2.7", "alias": "MiniMax-M2.7"],
+            ["name": "MiniMax-M2.7-highspeed", "alias": "MiniMax-M2.7-highspeed"],
+            ["name": "MiniMax-M2.5", "alias": "MiniMax-M2.5"],
+            ["name": "MiniMax-M2.5-highspeed", "alias": "MiniMax-M2.5-highspeed"],
+            ["name": "MiniMax-M2.1", "alias": "MiniMax-M2.1"],
+            ["name": "MiniMax-M2.1-highspeed", "alias": "MiniMax-M2.1-highspeed"],
+            ["name": "MiniMax-M2", "alias": "MiniMax-M2"]
         ]
     }
 }

--- a/src/Sources/ConfigInputFingerprint.swift
+++ b/src/Sources/ConfigInputFingerprint.swift
@@ -26,7 +26,9 @@ enum ConfigInputFingerprint {
             guard file.pathExtension == "json" else {
                 return false
             }
-            return name.hasPrefix("zai-") || name.hasPrefix("openai-compat-")
+            return name.hasPrefix("zai-")
+                || name.hasPrefix("minimax-")
+                || name.hasPrefix("openai-compat-")
         }
         .sorted { $0.lastPathComponent < $1.lastPathComponent }
 

--- a/src/Sources/ProviderCatalog.swift
+++ b/src/Sources/ProviderCatalog.swift
@@ -2,6 +2,11 @@ import Foundation
 
 enum ProviderCatalog {
     static let managedZAIProviderName = "zai"
+    static let managedMiniMaxProviderName = "minimax"
+    static let managedOpenAICompatibleProviderNames: Set<String> = [
+        managedZAIProviderName,
+        managedMiniMaxProviderName
+    ]
 
     /// OAuth provider keys used in config.yaml oauth-excluded-models.
     static let oauthProviderKeys: [String: String] = [
@@ -16,5 +21,5 @@ enum ProviderCatalog {
 
     static let reservedCustomProviderKeys = Set(oauthProviderKeys.keys)
         .union(oauthProviderKeys.values)
-        .union([managedZAIProviderName])
+        .union(managedOpenAICompatibleProviderNames)
 }

--- a/src/Sources/ServerManager.swift
+++ b/src/Sources/ServerManager.swift
@@ -92,6 +92,7 @@ class ServerManager: ObservableObject {
     private let configInputStateQueue = DispatchQueue(label: "io.automaze.vibeproxy.config-input-state", qos: .userInitiated)
     private let configResolutionQueue = DispatchQueue(label: "io.automaze.vibeproxy.config-resolution", qos: .userInitiated)
     private lazy var zaiAPIKeyStore = ZAIAPIKeyStore(directoryURL: authDirectoryURL())
+    private lazy var miniMaxAPIKeyStore = MiniMaxAPIKeyStore(directoryURL: authDirectoryURL())
     private lazy var customProviderCredentialStore = CustomProviderCredentialStore(directoryURL: authDirectoryURL())
     private var activeConfigPath = ""
     private var isRestartingForConfigUpdate = false
@@ -233,7 +234,7 @@ class ServerManager: ObservableObject {
             return
         }
         
-        // Use config path (merged with Z.AI if keys exist)
+        // Use config path merged with managed provider keys when present.
         let configPath = getConfigPath()
         guard !configPath.isEmpty && FileManager.default.fileExists(atPath: configPath) else {
             addLog("❌ Error: \(configErrorMessage ?? "Could not resolve active config path")")
@@ -653,6 +654,26 @@ class ServerManager: ObservableObject {
             }
         }
     }
+
+    /// Saves a MiniMax API key to the auth directory
+    func saveMiniMaxApiKey(_ apiKey: String, completion: @escaping (Bool, String) -> Void) {
+        credentialMutationQueue.async { [weak self] in
+            guard let self else { return }
+
+            do {
+                let filePath = try self.miniMaxAPIKeyStore.save(apiKey: apiKey)
+                self.addLog("✓ MiniMax API key saved to \(filePath.lastPathComponent)")
+                self.refreshAuthBackedConfiguration()
+                DispatchQueue.main.async {
+                    completion(true, "API key saved successfully")
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    completion(false, error.localizedDescription)
+                }
+            }
+        }
+    }
     
     func saveCustomProviderAPIKey(providerID: String, apiKey: String, completion: @escaping (Bool, String) -> Void) {
         credentialMutationQueue.async { [weak self] in
@@ -831,6 +852,7 @@ class ServerManager: ObservableObject {
         
         let authDir = authDirectoryURL()
         let zaiApiKeys = loadZaiAPIKeys()
+        let miniMaxApiKeys = loadMiniMaxAPIKeys()
         let customAuthRecords = loadCustomProviderCredentialRecords()
         let managedCustomProviders = ConfigComposer.parseCustomProviders(
             from: baseConfig.root,
@@ -856,6 +878,7 @@ class ServerManager: ObservableObject {
             disabledCustomProviderIDs: disabledCustomProviderIDs,
             disabledOAuthProviderKeys: disabledProviders,
             zaiAPIKeys: zaiApiKeys,
+            miniMaxAPIKeys: miniMaxApiKeys,
             customProviderAuthRecords: customAuthRecords.map {
                 ConfigProviderAuthRecord(
                     providerID: $0.providerID,
@@ -868,7 +891,13 @@ class ServerManager: ObservableObject {
                 baseConfigRoot: baseConfig.root,
                 enabledProviderStates: enabledProviderStates
             ),
-            managedZAIProviderName: ProviderCatalog.managedZAIProviderName
+            includeManagedMiniMaxProvider: isProviderEnabled(
+                ProviderCatalog.managedMiniMaxProviderName,
+                baseConfigRoot: baseConfig.root,
+                enabledProviderStates: enabledProviderStates
+            ),
+            managedZAIProviderName: ProviderCatalog.managedZAIProviderName,
+            managedMiniMaxProviderName: ProviderCatalog.managedMiniMaxProviderName
         )
         
         let mergedConfigPath = authDir.appendingPathComponent(CustomProviderConstants.mergedConfigFilename)
@@ -1050,6 +1079,14 @@ class ServerManager: ObservableObject {
         let loadResult = zaiAPIKeyStore.loadActiveAPIKeys()
         for issue in loadResult.issues {
             NSLog("[ServerManager] Ignoring Z.AI API key file at %@: %@", issue.filePath.path, issue.message)
+        }
+        return loadResult.apiKeys
+    }
+
+    private func loadMiniMaxAPIKeys() -> [String] {
+        let loadResult = miniMaxAPIKeyStore.loadActiveAPIKeys()
+        for issue in loadResult.issues {
+            NSLog("[ServerManager] Ignoring MiniMax API key file at %@: %@", issue.filePath.path, issue.message)
         }
         return loadResult.apiKeys
     }

--- a/src/Sources/ServiceType+ConnectionAction.swift
+++ b/src/Sources/ServiceType+ConnectionAction.swift
@@ -2,6 +2,7 @@ enum ServiceConnectionAction: Equatable {
     case authCommand(AuthCommand)
     case promptForQwenEmail
     case promptForZAIAPIKey
+    case promptForMiniMaxAPIKey
 }
 
 extension ServiceType {
@@ -23,6 +24,8 @@ extension ServiceType {
             return .authCommand(.antigravityLogin)
         case .zai:
             return .promptForZAIAPIKey
+        case .minimax:
+            return .promptForMiniMaxAPIKey
         }
     }
 }

--- a/src/Sources/SettingsView.swift
+++ b/src/Sources/SettingsView.swift
@@ -518,6 +518,8 @@ struct SettingsView: View {
     @State private var qwenEmail = ""
     @State private var showingZaiApiKeyPrompt = false
     @State private var zaiApiKey = ""
+    @State private var showingMiniMaxApiKeyPrompt = false
+    @State private var miniMaxApiKey = ""
     @State private var selectedCustomProvider: CustomProviderDefinition?
     @State private var customProviderApiKey = ""
     @State private var expandedRowCount = 0
@@ -735,6 +737,25 @@ struct SettingsView: View {
                         onToggleEnabled: { enabled in serverManager.setProviderEnabled("zai", enabled: enabled) },
                         onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
                     ) { EmptyView() }
+
+                    ServiceRow(
+                        serviceType: .minimax,
+                        iconName: "icon-minimax.png",
+                        iconSystemName: "sparkles",
+                        accounts: authManager.accounts(for: .minimax),
+                        isAuthenticating: authenticatingService == .minimax,
+                        helpText: "MiniMax provides OpenAI-compatible API access. Get your key at https://platform.minimax.io.",
+                        isEnabled: serverManager.isProviderEnabled("minimax"),
+                        isToggleLocked: serverManager.isProviderToggleLocked("minimax"),
+                        toggleHelpText: serverManager.providerConfigLockReason("minimax"),
+                        disabledReasonText: serverManager.providerConfigLockReason("minimax"),
+                        customTitle: nil,
+                        onConnect: { showingMiniMaxApiKeyPrompt = true },
+                        onDisconnect: { account in disconnectAccount(account) },
+                        onToggleDisabled: { account in toggleAccountDisabled(account) },
+                        onToggleEnabled: { enabled in serverManager.setProviderEnabled("minimax", enabled: enabled) },
+                        onExpandChange: { expanded in expandedRowCount += expanded ? 1 : -1 }
+                    ) { EmptyView() }
                 }
                 
                 if !serverManager.customProviders.isEmpty {
@@ -871,6 +892,32 @@ struct SettingsView: View {
             .padding(24)
             .frame(width: 400)
         }
+        .sheet(isPresented: $showingMiniMaxApiKeyPrompt) {
+            VStack(spacing: 16) {
+                Text("MiniMax API Key")
+                    .font(.headline)
+                Text("Enter your MiniMax API key from https://platform.minimax.io")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                SecureField("", text: $miniMaxApiKey)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 300)
+                HStack(spacing: 12) {
+                    Button("Cancel") {
+                        showingMiniMaxApiKeyPrompt = false
+                        miniMaxApiKey = ""
+                    }
+                    Button("Add Key") {
+                        showingMiniMaxApiKeyPrompt = false
+                        startMiniMaxAuth(apiKey: miniMaxApiKey)
+                    }
+                    .disabled(miniMaxApiKey.isEmpty)
+                    .keyboardShortcut(.defaultAction)
+                }
+            }
+            .padding(24)
+            .frame(width: 400)
+        }
         .sheet(item: $selectedCustomProvider, onDismiss: {
             customProviderApiKey = ""
         }) { provider in
@@ -971,6 +1018,9 @@ struct SettingsView: View {
         case .promptForZAIAPIKey:
             authenticatingService = nil
             return // handled separately with API key prompt
+        case .promptForMiniMaxAPIKey:
+            authenticatingService = nil
+            return // handled separately with API key prompt
         }
         
         serverManager.runAuthCommand(command) { success, output in
@@ -1014,6 +1064,8 @@ struct SettingsView: View {
             return "🌐 Browser opened for Antigravity authentication.\n\nPlease complete the login in your browser."
         case .zai:
             return "✓ Z.AI API key added successfully.\n\nYou can now use GLM models through the proxy."
+        case .minimax:
+            return "✓ MiniMax API key added successfully.\n\nYou can now use MiniMax models through the proxy."
         }
     }
     
@@ -1053,6 +1105,30 @@ struct SettingsView: View {
                 if success {
                     self.authResultSuccess = true
                     self.authResultMessage = self.successMessage(for: .zai)
+                    self.showingAuthResult = true
+                    self.authManager.checkAuthStatus()
+                } else {
+                    self.authResultSuccess = false
+                    self.authResultMessage = "Failed to save API key.\n\nDetails: \(output.isEmpty ? "Unknown error" : output)"
+                    self.showingAuthResult = true
+                }
+            }
+        }
+    }
+
+    private func startMiniMaxAuth(apiKey: String) {
+        authenticatingService = .minimax
+        NSLog("[SettingsView] Adding MiniMax API key")
+
+        serverManager.saveMiniMaxApiKey(apiKey) { success, output in
+            NSLog("[SettingsView] MiniMax key save completed - success: %d, output: %@", success, output)
+            DispatchQueue.main.async {
+                self.authenticatingService = nil
+                self.miniMaxApiKey = ""
+
+                if success {
+                    self.authResultSuccess = true
+                    self.authResultMessage = self.successMessage(for: .minimax)
                     self.showingAuthResult = true
                     self.authManager.checkAuthStatus()
                 } else {

--- a/src/Sources/ZAIAPIKeyStore.swift
+++ b/src/Sources/ZAIAPIKeyStore.swift
@@ -1,16 +1,16 @@
 import Foundation
 
-struct ZAIAPIKeyLoadIssue: Equatable {
+struct ManagedProviderAPIKeyLoadIssue: Equatable {
     let filePath: URL
     let message: String
 }
 
-struct ZAIAPIKeyLoadResult: Equatable {
+struct ManagedProviderAPIKeyLoadResult: Equatable {
     let apiKeys: [String]
-    let issues: [ZAIAPIKeyLoadIssue]
+    let issues: [ManagedProviderAPIKeyLoadIssue]
 }
 
-enum ZAIAPIKeyStoreError: LocalizedError {
+enum ManagedProviderAPIKeyStoreError: LocalizedError {
     case failedToCreateDirectory(String)
     case failedToSerializeKey(String)
     case failedToWriteKey(String)
@@ -31,18 +31,25 @@ enum ZAIAPIKeyStoreError: LocalizedError {
     }
 }
 
-final class ZAIAPIKeyStore {
-    static let authType = "zai"
+private struct ManagedProviderAPIKeyDescriptor {
+    let authType: String
+    let filePrefix: String
+    let displayName: String
+}
 
+private final class ManagedProviderAPIKeyStore {
+    private let descriptor: ManagedProviderAPIKeyDescriptor
     private let directoryURL: URL
     private let fileManager: FileManager
     private let queue: DispatchQueue
 
     init(
+        descriptor: ManagedProviderAPIKeyDescriptor,
         directoryURL: URL,
         fileManager: FileManager = .default,
-        queueLabel: String = "io.automaze.vibeproxy.zai-api-keys"
+        queueLabel: String
     ) {
+        self.descriptor = descriptor
         self.directoryURL = directoryURL
         self.fileManager = fileManager
         self.queue = DispatchQueue(label: queueLabel, qos: .userInitiated)
@@ -56,15 +63,15 @@ final class ZAIAPIKeyStore {
             do {
                 try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
             } catch {
-                throw ZAIAPIKeyStoreError.failedToCreateDirectory(
+                throw ManagedProviderAPIKeyStoreError.failedToCreateDirectory(
                     "Failed to create auth directory at \(directoryURL.path): \(error.localizedDescription)"
                 )
             }
 
-            let filename = "zai-\(UUID().uuidString.prefix(8)).json"
+            let filename = "\(descriptor.filePrefix)-\(UUID().uuidString.prefix(8)).json"
             let filePath = directoryURL.appendingPathComponent(filename)
             let authData: [String: Any] = [
-                "type": Self.authType,
+                "type": descriptor.authType,
                 "email": maskAPIKey(apiKey),
                 "api_key": apiKey,
                 "created": createdAt
@@ -74,8 +81,8 @@ final class ZAIAPIKeyStore {
             do {
                 jsonData = try JSONSerialization.data(withJSONObject: authData, options: .prettyPrinted)
             } catch {
-                throw ZAIAPIKeyStoreError.failedToSerializeKey(
-                    "Failed to serialize Z.AI API key: \(error.localizedDescription)"
+                throw ManagedProviderAPIKeyStoreError.failedToSerializeKey(
+                    "Failed to serialize \(descriptor.displayName) API key: \(error.localizedDescription)"
                 )
             }
 
@@ -83,8 +90,8 @@ final class ZAIAPIKeyStore {
                 try jsonData.write(to: filePath, options: .atomic)
                 try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: filePath.path)
             } catch {
-                throw ZAIAPIKeyStoreError.failedToWriteKey(
-                    "Failed to write Z.AI API key file at \(filePath.path): \(error.localizedDescription)"
+                throw ManagedProviderAPIKeyStoreError.failedToWriteKey(
+                    "Failed to write \(descriptor.displayName) API key file at \(filePath.path): \(error.localizedDescription)"
                 )
             }
 
@@ -92,33 +99,33 @@ final class ZAIAPIKeyStore {
         }
     }
 
-    func loadActiveAPIKeys() -> ZAIAPIKeyLoadResult {
+    func loadActiveAPIKeys() -> ManagedProviderAPIKeyLoadResult {
         queue.sync {
             guard let files = try? fileManager.contentsOfDirectory(
                 at: directoryURL,
                 includingPropertiesForKeys: nil
             ) else {
-                return ZAIAPIKeyLoadResult(apiKeys: [], issues: [])
+                return ManagedProviderAPIKeyLoadResult(apiKeys: [], issues: [])
             }
 
             var apiKeys: [String] = []
-            var issues: [ZAIAPIKeyLoadIssue] = []
+            var issues: [ManagedProviderAPIKeyLoadIssue] = []
 
             for file in files where isManagedKeyFile(file) {
                 do {
                     if let apiKey = try loadActiveAPIKey(at: file) {
                         apiKeys.append(apiKey)
                     }
-                } catch let error as ZAIAPIKeyStoreError {
+                } catch let error as ManagedProviderAPIKeyStoreError {
                     issues.append(
-                        ZAIAPIKeyLoadIssue(
+                        ManagedProviderAPIKeyLoadIssue(
                             filePath: file,
                             message: error.localizedDescription
                         )
                     )
                 } catch {
                     issues.append(
-                        ZAIAPIKeyLoadIssue(
+                        ManagedProviderAPIKeyLoadIssue(
                             filePath: file,
                             message: "Unexpected error while loading \(file.path): \(error.localizedDescription)"
                         )
@@ -126,7 +133,7 @@ final class ZAIAPIKeyStore {
                 }
             }
 
-            return ZAIAPIKeyLoadResult(apiKeys: apiKeys, issues: issues)
+            return ManagedProviderAPIKeyLoadResult(apiKeys: apiKeys, issues: issues)
         }
     }
 
@@ -135,8 +142,8 @@ final class ZAIAPIKeyStore {
         do {
             data = try Data(contentsOf: filePath)
         } catch {
-            throw ZAIAPIKeyStoreError.failedToReadKey(
-                "Failed to read Z.AI API key file at \(filePath.path): \(error.localizedDescription)"
+            throw ManagedProviderAPIKeyStoreError.failedToReadKey(
+                "Failed to read \(descriptor.displayName) API key file at \(filePath.path): \(error.localizedDescription)"
             )
         }
 
@@ -144,24 +151,24 @@ final class ZAIAPIKeyStore {
         do {
             jsonObject = try JSONSerialization.jsonObject(with: data)
         } catch {
-            throw ZAIAPIKeyStoreError.invalidKeyJSON(
-                "Z.AI API key file at \(filePath.path) contains invalid JSON: \(error.localizedDescription)"
+            throw ManagedProviderAPIKeyStoreError.invalidKeyJSON(
+                "\(descriptor.displayName) API key file at \(filePath.path) contains invalid JSON: \(error.localizedDescription)"
             )
         }
 
         guard let json = ConfigComposer.stringKeyedDictionary(jsonObject) else {
-            throw ZAIAPIKeyStoreError.malformedKey(
-                "Z.AI API key file at \(filePath.path) must contain a JSON object."
+            throw ManagedProviderAPIKeyStoreError.malformedKey(
+                "\(descriptor.displayName) API key file at \(filePath.path) must contain a JSON object."
             )
         }
-        guard (json["type"] as? String) == Self.authType else {
-            throw ZAIAPIKeyStoreError.malformedKey(
-                "Z.AI API key file at \(filePath.path) has an unexpected type."
+        guard (json["type"] as? String) == descriptor.authType else {
+            throw ManagedProviderAPIKeyStoreError.malformedKey(
+                "\(descriptor.displayName) API key file at \(filePath.path) has an unexpected type."
             )
         }
         guard let apiKey = json["api_key"] as? String, !apiKey.isEmpty else {
-            throw ZAIAPIKeyStoreError.malformedKey(
-                "Z.AI API key file at \(filePath.path) is missing an api_key."
+            throw ManagedProviderAPIKeyStoreError.malformedKey(
+                "\(descriptor.displayName) API key file at \(filePath.path) is missing an api_key."
             )
         }
         guard json["disabled"] as? Bool != true else {
@@ -171,7 +178,7 @@ final class ZAIAPIKeyStore {
     }
 
     private func isManagedKeyFile(_ file: URL) -> Bool {
-        file.lastPathComponent.hasPrefix("zai-") && file.pathExtension == "json"
+        file.lastPathComponent.hasPrefix("\(descriptor.filePrefix)-") && file.pathExtension == "json"
     }
 
     private func maskAPIKey(_ apiKey: String) -> String {
@@ -179,5 +186,69 @@ final class ZAIAPIKeyStore {
             return apiKey
         }
         return String(apiKey.prefix(8)) + "..." + String(apiKey.suffix(4))
+    }
+}
+
+final class ZAIAPIKeyStore {
+    private let backingStore: ManagedProviderAPIKeyStore
+
+    init(
+        directoryURL: URL,
+        fileManager: FileManager = .default,
+        queueLabel: String = "io.automaze.vibeproxy.zai-api-keys"
+    ) {
+        self.backingStore = ManagedProviderAPIKeyStore(
+            descriptor: ManagedProviderAPIKeyDescriptor(
+                authType: ProviderCatalog.managedZAIProviderName,
+                filePrefix: ProviderCatalog.managedZAIProviderName,
+                displayName: "Z.AI"
+            ),
+            directoryURL: directoryURL,
+            fileManager: fileManager,
+            queueLabel: queueLabel
+        )
+    }
+
+    func save(
+        apiKey: String,
+        createdAt: String = ISO8601DateFormatter().string(from: Date())
+    ) throws -> URL {
+        try backingStore.save(apiKey: apiKey, createdAt: createdAt)
+    }
+
+    func loadActiveAPIKeys() -> ManagedProviderAPIKeyLoadResult {
+        backingStore.loadActiveAPIKeys()
+    }
+}
+
+final class MiniMaxAPIKeyStore {
+    private let backingStore: ManagedProviderAPIKeyStore
+
+    init(
+        directoryURL: URL,
+        fileManager: FileManager = .default,
+        queueLabel: String = "io.automaze.vibeproxy.minimax-api-keys"
+    ) {
+        self.backingStore = ManagedProviderAPIKeyStore(
+            descriptor: ManagedProviderAPIKeyDescriptor(
+                authType: ProviderCatalog.managedMiniMaxProviderName,
+                filePrefix: ProviderCatalog.managedMiniMaxProviderName,
+                displayName: "MiniMax"
+            ),
+            directoryURL: directoryURL,
+            fileManager: fileManager,
+            queueLabel: queueLabel
+        )
+    }
+
+    func save(
+        apiKey: String,
+        createdAt: String = ISO8601DateFormatter().string(from: Date())
+    ) throws -> URL {
+        try backingStore.save(apiKey: apiKey, createdAt: createdAt)
+    }
+
+    func loadActiveAPIKeys() -> ManagedProviderAPIKeyLoadResult {
+        backingStore.loadActiveAPIKeys()
     }
 }

--- a/src/Tests/ProviderWiringTests.swift
+++ b/src/Tests/ProviderWiringTests.swift
@@ -11,10 +11,17 @@ final class ProviderWiringTests: XCTestCase {
         XCTAssertEqual(ServiceType.qwen.connectionAction, .promptForQwenEmail)
         XCTAssertEqual(ServiceType.antigravity.connectionAction, .authCommand(.antigravityLogin))
         XCTAssertEqual(ServiceType.zai.connectionAction, .promptForZAIAPIKey)
+        XCTAssertEqual(ServiceType.minimax.connectionAction, .promptForMiniMaxAPIKey)
     }
 
     func testKimiProviderCatalogRegistrationMatchesRuntimeProviderKey() {
         XCTAssertEqual(ProviderCatalog.oauthProviderKeys["kimi"], "kimi")
         XCTAssertTrue(ProviderCatalog.reservedCustomProviderKeys.contains("kimi"))
+    }
+
+    func testManagedOpenAICompatibleProviderCatalogRegistration() {
+        XCTAssertTrue(ProviderCatalog.managedOpenAICompatibleProviderNames.contains("zai"))
+        XCTAssertTrue(ProviderCatalog.managedOpenAICompatibleProviderNames.contains("minimax"))
+        XCTAssertTrue(ProviderCatalog.reservedCustomProviderKeys.contains("minimax"))
     }
 }

--- a/src/Verification/ConfigComposerSpec.swift
+++ b/src/Verification/ConfigComposerSpec.swift
@@ -193,8 +193,10 @@ struct ConfigComposerSpec {
                 disabledCustomProviderIDs: [],
                 disabledOAuthProviderKeys: ["gemini-cli"],
                 zaiAPIKeys: [],
+                miniMaxAPIKeys: [],
                 customProviderAuthRecords: [],
-                includeManagedZAIProvider: false
+                includeManagedZAIProvider: false,
+                includeManagedMiniMaxProvider: false
             )
 
             let exclusions = dictionary(runtime["oauth-excluded-models"])
@@ -229,12 +231,14 @@ struct ConfigComposerSpec {
                 disabledCustomProviderIDs: [],
                 disabledOAuthProviderKeys: [],
                 zaiAPIKeys: ["zai-key-1"],
+                miniMaxAPIKeys: ["minimax-key-1"],
                 customProviderAuthRecords: [
                     ConfigProviderAuthRecord(providerID: "nvidia", apiKey: "inline-a", isDisabled: false),
                     ConfigProviderAuthRecord(providerID: "nvidia", apiKey: "auth-c", isDisabled: false),
                     ConfigProviderAuthRecord(providerID: "nvidia", apiKey: "auth-d", isDisabled: true)
                 ],
-                includeManagedZAIProvider: true
+                includeManagedZAIProvider: true,
+                includeManagedMiniMaxProvider: true
             )
 
             let nvidia = provider(named: "nvidia", in: runtime)
@@ -245,6 +249,10 @@ struct ConfigComposerSpec {
 
             let zai = provider(named: "zai", in: runtime)
             expectEqual(apiKeys(in: zai ?? [:]), ["zai-key-1"], "managed zai provider should be injected", recorder: recorder)
+
+            let minimax = provider(named: "minimax", in: runtime)
+            expectEqual(apiKeys(in: minimax ?? [:]), ["minimax-key-1"], "managed minimax provider should be injected", recorder: recorder)
+            expectEqual(minimax?["base-url"] as? String, "https://api.minimax.io/v1", "managed minimax provider should use the OpenAI-compatible endpoint", recorder: recorder)
         }
 
         run("composeRuntimeConfig preserves user-authored zai models and merges inline plus managed keys", recorder: recorder) {
@@ -272,8 +280,10 @@ struct ConfigComposerSpec {
                 disabledCustomProviderIDs: [],
                 disabledOAuthProviderKeys: [],
                 zaiAPIKeys: ["managed-zai", "inline-zai"],
+                miniMaxAPIKeys: [],
                 customProviderAuthRecords: [],
-                includeManagedZAIProvider: true
+                includeManagedZAIProvider: true,
+                includeManagedMiniMaxProvider: false
             )
 
             let zai = provider(named: "zai", in: runtime)
@@ -315,10 +325,12 @@ struct ConfigComposerSpec {
                 disabledCustomProviderIDs: ["nvidia"],
                 disabledOAuthProviderKeys: [],
                 zaiAPIKeys: [],
+                miniMaxAPIKeys: [],
                 customProviderAuthRecords: [
                     ConfigProviderAuthRecord(providerID: "nvidia", apiKey: "auth-a", isDisabled: false)
                 ],
-                includeManagedZAIProvider: false
+                includeManagedZAIProvider: false,
+                includeManagedMiniMaxProvider: false
             )
 
             expectNil(provider(named: "nvidia", in: runtime), "disabled custom providers should be omitted from runtime config", recorder: recorder)
@@ -355,6 +367,10 @@ struct ConfigComposerSpec {
                     ],
                     [
                         "name": "zai",
+                        "base-url": ""
+                    ],
+                    [
+                        "name": "minimax",
                         "base-url": ""
                     ]
                 ]

--- a/src/Verification/ConfigInputFingerprintSpec.swift
+++ b/src/Verification/ConfigInputFingerprintSpec.swift
@@ -9,6 +9,7 @@ struct ConfigInputFingerprintSpec {
             withTemporaryDirectory(recorder: recorder) { directoryURL in
                 writeText("port: 8317\n", to: directoryURL.appendingPathComponent("config.yaml"), recorder: recorder)
                 writeText("{\"type\":\"zai\",\"api_key\":\"zai-1\"}\n", to: directoryURL.appendingPathComponent("zai-a.json"), recorder: recorder)
+                writeText("{\"type\":\"minimax\",\"api_key\":\"mini-1\"}\n", to: directoryURL.appendingPathComponent("minimax-a.json"), recorder: recorder)
                 writeText("{\"type\":\"openai-compat\",\"provider\":\"nvidia\",\"api_key\":\"nvapi-1\"}\n", to: directoryURL.appendingPathComponent("openai-compat-nvidia-a.json"), recorder: recorder)
                 writeText("{\"type\":\"claude\"}\n", to: directoryURL.appendingPathComponent("claude.json"), recorder: recorder)
                 writeText("generated: true\n", to: directoryURL.appendingPathComponent("merged-config.yaml"), recorder: recorder)
@@ -18,7 +19,7 @@ struct ConfigInputFingerprintSpec {
 
                 expectEqual(
                     names,
-                    ["config.yaml", "openai-compat-nvidia-a.json", "zai-a.json"],
+                    ["config.yaml", "minimax-a.json", "openai-compat-nvidia-a.json", "zai-a.json"],
                     "only additive config and managed API key files should affect the fingerprint",
                     recorder: recorder
                 )

--- a/src/Verification/ZAIAPIKeyStoreSpec.swift
+++ b/src/Verification/ZAIAPIKeyStoreSpec.swift
@@ -24,6 +24,26 @@ struct ZAIAPIKeyStoreSpec {
             }
         }
 
+        run("save and load active MiniMax API keys", recorder: recorder) {
+            withTemporaryDirectory(recorder: recorder) { directoryURL in
+                let store = MiniMaxAPIKeyStore(directoryURL: directoryURL)
+                let filePath = expectNoThrow(
+                    recorder: recorder,
+                    "saving a valid MiniMax API key should succeed"
+                ) {
+                    try store.save(apiKey: "minimax-1234567890abcdef")
+                }
+
+                guard let filePath else { return }
+
+                let loadResult = store.loadActiveAPIKeys()
+                expectEqual(loadResult.issues.count, 0, "valid MiniMax key files should load without issues", recorder: recorder)
+                expectEqual(loadResult.apiKeys, ["minimax-1234567890abcdef"], "saved MiniMax key should be returned as active", recorder: recorder)
+                expectEqual(filePath.lastPathComponent.hasPrefix("minimax-"), true, "MiniMax key files should use the minimax prefix", recorder: recorder)
+                expectEqual(filePermissions(at: filePath), 0o600, "MiniMax key files should be written with 0600 permissions", recorder: recorder)
+            }
+        }
+
         run("disabled Z.AI API keys are excluded from the active runtime set", recorder: recorder) {
             withTemporaryDirectory(recorder: recorder) { directoryURL in
                 let store = ZAIAPIKeyStore(directoryURL: directoryURL)


### PR DESCRIPTION
## Summary
- Add MiniMax as a first-class API-key provider in Settings
- Store `minimax-*.json` auth files and include them in config hot-reload fingerprints
- Inject a managed OpenAI-compatible MiniMax provider using `https://api.minimax.io/v1` with default MiniMax model aliases
- Update provider wiring tests, verification specs, README, and Factory setup docs

MiniMax OpenAI-compatible API reference: https://platform.minimax.io/docs/api-reference/text-openai-api

## Testing
- `cd src && swift test`
- `make test`
- `swiftc Sources/ProviderCatalog.swift Sources/CustomProviders.swift Sources/ConfigComposer.swift Verification/ConfigComposerSpec.swift -o /tmp/ConfigComposerSpec && /tmp/ConfigComposerSpec`
- `swiftc Sources/ProviderCatalog.swift Sources/CustomProviders.swift Sources/ConfigComposer.swift Sources/ZAIAPIKeyStore.swift Verification/ZAIAPIKeyStoreSpec.swift -o /tmp/ZAIAPIKeyStoreSpec && /tmp/ZAIAPIKeyStoreSpec`
- `swiftc Sources/ConfigInputFingerprint.swift Verification/ConfigInputFingerprintSpec.swift -o /tmp/ConfigInputFingerprintSpec && /tmp/ConfigInputFingerprintSpec`
- `git diff --check`

Note: `swift test` still emits the existing `AppDelegate.windowDidClose` / `windowDidExpose` warning unrelated to this change.