### PR TITLE
feat(linux): add package builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,9 +251,55 @@ jobs:
             sparkle_length_${{ matrix.arch }}.txt
           retention-days: 1
 
+  build-linux-packages:
+    name: Build Linux Packages (${{ matrix.arch }})
+    needs: get-cliproxy-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Get version from tag
+        id: get_version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Build .deb and .rpm
+        env:
+          ARCH: ${{ matrix.arch }}
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          CLIPROXY_VERSION: ${{ needs.get-cliproxy-version.outputs.version }}
+        run: |
+          chmod +x scripts/package-linux.sh
+          scripts/package-linux.sh
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: vibeproxy-linux-${{ matrix.arch }}
+          path: |
+            dist/VibeProxy-linux-${{ matrix.arch }}.deb
+            dist/VibeProxy-linux-${{ matrix.arch }}.rpm
+            dist/VibeProxy-linux-${{ matrix.arch }}.sha256
+          retention-days: 1
+
   release:
     name: Create Release
-    needs: [get-cliproxy-version, build-signed]
+    needs: [get-cliproxy-version, build-signed, build-linux-packages]
     runs-on: macos-14
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -279,6 +325,8 @@ jobs:
           mkdir -p release
           cp artifacts/vibeproxy-arm64/* release/
           cp artifacts/vibeproxy-x86_64/* release/
+          cp artifacts/vibeproxy-linux-amd64/* release/
+          cp artifacts/vibeproxy-linux-arm64/* release/
           ls -la release/
 
       - name: Download Sparkle signatures
@@ -371,7 +419,7 @@ jobs:
           git push origin main
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             release/VibeProxy-arm64.zip
@@ -382,6 +430,12 @@ jobs:
             release/VibeProxy-x86_64.zip.sha256
             release/VibeProxy-x86_64.dmg
             release/VibeProxy-x86_64.dmg.sha256
+            release/VibeProxy-linux-amd64.deb
+            release/VibeProxy-linux-amd64.rpm
+            release/VibeProxy-linux-amd64.sha256
+            release/VibeProxy-linux-arm64.deb
+            release/VibeProxy-linux-arm64.rpm
+            release/VibeProxy-linux-arm64.sha256
           draft: false
           prerelease: false
           generate_release_notes: true
@@ -395,14 +449,26 @@ jobs:
             | **Apple Silicon** (M1/M2/M3) | `VibeProxy-arm64.dmg` | `VibeProxy-arm64.zip` |
             | **Intel** (x86_64) ⚠️ | `VibeProxy-x86_64.dmg` | `VibeProxy-x86_64.zip` |
 
+            | Linux Architecture | DEB | RPM |
+            |--------------------|-----|-----|
+            | **amd64** | `VibeProxy-linux-amd64.deb` | `VibeProxy-linux-amd64.rpm` |
+            | **arm64** | `VibeProxy-linux-arm64.deb` | `VibeProxy-linux-arm64.rpm` |
+
             > ⚠️ **Intel build is untested** - Please report if it works for you!
 
             ### Installation
 
-            1. Download the appropriate file for your Mac
+            1. Download the appropriate file for your platform
             2. For DMG: Mount and drag to Applications
             3. For ZIP: Extract and drag to Applications
             4. Double-click to launch
+
+            Linux packages install `/usr/bin/vibeproxy` and an optional user service:
+
+            ```bash
+            systemctl --user daemon-reload
+            systemctl --user enable --now vibeproxy.service
+            ```
 
             ### What's New
 
@@ -410,10 +476,11 @@ jobs:
 
             ### Verification
 
-            This release is **code signed** with Apple Developer ID and includes SHA-256 checksums.
+            macOS artifacts are code signed with Apple Developer ID. Linux packages are unsigned and include SHA-256 checksums.
 
             ```bash
             shasum -a 256 -c VibeProxy-arm64.zip.sha256
+            sha256sum -c VibeProxy-linux-amd64.sha256
             ```
 
             ---

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ xcuserdata/
 *.app
 *.zip
 *.dmg
+dist/
+build/linux/
+.cache/linux-packaging/
 
 # macOS
 .DS_Store

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,6 +1,6 @@
 # Installing VibeProxy
 
-**⚠️ Requirements:** macOS running on **Apple Silicon only** (M1/M2/M3/M4 Macs). Intel Macs are not supported.
+**⚠️ Requirements:** macOS 13+ for the menu bar app, or Linux amd64/arm64 for the packaged proxy backend.
 
 ## Option 1: Download Pre-built Release (Recommended)
 
@@ -9,6 +9,28 @@
 1. Go to the [**Releases**](https://github.com/automazeio/vibeproxy/releases) page
 2. Download the latest `VibeProxy.zip`
 3. Extract the ZIP file
+
+### Linux packages
+
+Download the package for your architecture from the Releases page:
+
+```sh
+sudo apt install ./VibeProxy-linux-amd64.deb
+sudo dnf install ./VibeProxy-linux-amd64.rpm
+```
+
+Then run:
+
+```sh
+vibeproxy
+```
+
+Or enable the user service:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now vibeproxy.service
+```
 
 ### Step 2: Install
 
@@ -83,6 +105,9 @@ make install
 
 # Clean build artifacts
 make clean
+
+# Build Linux .deb and .rpm packages
+make package-linux
 ```
 
 ### Code Signing (Optional)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build app install clean run help
+.PHONY: build app install package-linux clean run help
 
 help: ## Show this help message
 	@echo "VibeProxy - macOS Menu Bar App"
@@ -27,6 +27,10 @@ install: app ## Build and install to /Applications
 	@cp -r "VibeProxy.app" /Applications/
 	@echo "✅ Installed to /Applications/VibeProxy.app"
 
+package-linux: ## Create Linux .deb and .rpm packages
+	@echo "📦 Creating Linux packages..."
+	@scripts/package-linux.sh
+
 run: app ## Build and run the app
 	@echo "🚀 Launching app..."
 	@open "VibeProxy.app"
@@ -38,6 +42,8 @@ clean: ## Clean build artifacts
 	@rm -rf src/Sources/Resources/cli-proxy-api
 	@rm -rf src/Sources/Resources/config.yaml
 	@rm -rf src/Sources/Resources/static
+	@rm -rf dist
+	@rm -rf build/linux
 	@echo "✅ Clean complete"
 
 test: ## Run a quick test build

--- a/README.md
+++ b/README.md
@@ -48,16 +48,19 @@ Built on [CLIProxyAPIPlus](https://github.com/router-for-me/CLIProxyAPIPlus), it
 
 ## Installation
 
-**Requirements:** macOS 13+ (Ventura or later)
+**Requirements:** macOS 13+ (Ventura or later) for the menu bar app, or Linux amd64/arm64 for the packaged proxy backend.
 
 ### Download Pre-built Release (Recommended)
 
 1. Go to the [**Releases**](https://github.com/automazeio/vibeproxy/releases) page
-2. Download the appropriate version for your Mac:
+2. Download the appropriate version:
    - **Apple Silicon** (M1/M2/M3/M4): `VibeProxy-arm64.zip`
    - **Intel**: `VibeProxy-x86_64.zip` *(untested - please report issues)*
-3. Extract and drag `VibeProxy.app` to `/Applications`
-4. Launch VibeProxy
+   - **Linux amd64**: `VibeProxy-linux-amd64.deb` or `VibeProxy-linux-amd64.rpm`
+   - **Linux arm64**: `VibeProxy-linux-arm64.deb` or `VibeProxy-linux-arm64.rpm`
+3. macOS: Extract and drag `VibeProxy.app` to `/Applications`
+4. Linux: Install the package and run `vibeproxy`, or enable the user service with `systemctl --user enable --now vibeproxy.service`
+5. Launch VibeProxy
 
 **Code Signed & Notarized** ✅ - No Gatekeeper warnings, installs seamlessly on macOS.
 
@@ -95,7 +98,8 @@ When you click "Add Account" for Z.AI GLM:
 
 ## Requirements
 
-- macOS 13.0 (Ventura) or later
+- macOS 13.0 (Ventura) or later for the menu bar app
+- Linux amd64 or arm64 for the packaged CLIProxyAPI backend
 
 ## Development
 

--- a/packaging/linux/README.linux
+++ b/packaging/linux/README.linux
@@ -1,0 +1,39 @@
+# VibeProxy for Linux
+
+This package installs the CLIProxyAPI backend used by VibeProxy and a thin
+Linux wrapper. It is a Linux CLI/backend package, not a port of the macOS menu
+bar UI.
+
+## Files
+
+- `/usr/bin/vibeproxy` starts the proxy with `/etc/vibeproxy/config.yaml`.
+- `/etc/vibeproxy/config.yaml` is the default configuration.
+- `/usr/lib/vibeproxy/cli-proxy-api-plus` is the bundled upstream proxy binary.
+- `/usr/lib/systemd/user/vibeproxy.service` is an optional user service.
+
+## Run
+
+```sh
+vibeproxy
+```
+
+The proxy listens on `127.0.0.1:8318` by default and stores credentials in
+`~/.cli-proxy-api`.
+
+Do not store provider secrets in `/etc/vibeproxy/config.yaml`; keep them in the
+per-user `~/.cli-proxy-api` files used by CLIProxyAPI.
+
+To run it as a user service:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now vibeproxy.service
+```
+
+Provider login commands are forwarded to the bundled proxy. For example:
+
+```sh
+vibeproxy -claude-login
+vibeproxy -codex-login
+vibeproxy -login
+```

--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -1,0 +1,36 @@
+name: vibeproxy
+arch: ${NFPM_ARCH}
+platform: linux
+version: ${VERSION}
+release: ${RELEASE}
+section: net
+priority: optional
+maintainer: Automaze <support@automaze.io>
+description: Local proxy for using AI subscriptions with coding tools.
+vendor: Automaze
+homepage: https://github.com/automazeio/vibeproxy
+license: MIT
+depends:
+  - ca-certificates
+contents:
+  - src: __LINUX_PACKAGE_ROOT__/usr/bin/vibeproxy
+    dst: /usr/bin/vibeproxy
+    file_info:
+      mode: 0755
+  - src: __LINUX_PACKAGE_ROOT__/usr/lib/vibeproxy/cli-proxy-api-plus
+    dst: /usr/lib/vibeproxy/cli-proxy-api-plus
+    file_info:
+      mode: 0755
+  - src: src/Sources/Resources/config.yaml
+    dst: /etc/vibeproxy/config.yaml
+    type: config|noreplace
+    file_info:
+      mode: 0644
+  - src: packaging/linux/vibeproxy.service
+    dst: /usr/lib/systemd/user/vibeproxy.service
+    file_info:
+      mode: 0644
+  - src: packaging/linux/README.linux
+    dst: /usr/share/doc/vibeproxy/README.linux
+    file_info:
+      mode: 0644

--- a/packaging/linux/vibeproxy
+++ b/packaging/linux/vibeproxy
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+binary="${VIBEPROXY_BINARY:-/usr/lib/vibeproxy/cli-proxy-api-plus}"
+config="${VIBEPROXY_CONFIG:-/etc/vibeproxy/config.yaml}"
+
+case "${1:-}" in
+  "" | serve)
+    [[ "${1:-}" == "serve" ]] && shift
+    exec "$binary" --config "$config" "$@"
+    ;;
+  --help | -h | version | --version)
+    exec "$binary" "$@"
+    ;;
+  -*)
+    exec "$binary" --config "$config" "$@"
+    ;;
+  *)
+    exec "$binary" "$@"
+    ;;
+esac

--- a/packaging/linux/vibeproxy.service
+++ b/packaging/linux/vibeproxy.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=VibeProxy local AI proxy
+Documentation=https://github.com/automazeio/vibeproxy
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/vibeproxy serve
+Restart=on-failure
+RestartSec=2
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ReadWritePaths=%h/.cli-proxy-api
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=default.target

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$project_dir"
+
+version="${VERSION:-$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || true)}"
+version="${version:-0.0.0}"
+release="${RELEASE:-1}"
+arch="${ARCH:-$(uname -m)}"
+dist_dir="${DIST_DIR:-$project_dir/dist}"
+cache_dir="${CACHE_DIR:-$project_dir/.cache/linux-packaging}"
+host_arch="$(uname -m)"
+nfpm_version="${NFPM_VERSION:-2.47.0}"
+
+case "$host_arch" in
+  x86_64 | amd64)
+    nfpm_host_arch=x86_64
+    ;;
+  aarch64 | arm64)
+    nfpm_host_arch=arm64
+    ;;
+  *)
+    echo "Unsupported nFPM host architecture: $host_arch" >&2
+    exit 1
+    ;;
+esac
+
+case "$arch" in
+  x86_64 | amd64)
+    nfpm_arch=amd64
+    asset_arch=amd64
+    ;;
+  aarch64 | arm64)
+    nfpm_arch=arm64
+    asset_arch=aarch64
+    ;;
+  *)
+    echo "Unsupported Linux architecture: $arch" >&2
+    exit 1
+    ;;
+esac
+
+package_root="$project_dir/build/linux/$nfpm_arch/package-root"
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need curl
+need jq
+need tar
+need sha256sum
+
+mkdir -p "$dist_dir" "$cache_dir" "$package_root/usr/bin" "$package_root/usr/lib/vibeproxy"
+
+if [[ -n "${CLIPROXY_VERSION:-}" ]]; then
+  cliproxy_tag="v${CLIPROXY_VERSION#v}"
+elif [[ -n "${CLIPROXY_TAG:-}" ]]; then
+  cliproxy_tag="$CLIPROXY_TAG"
+else
+  latest_json="$(curl -fsSL https://api.github.com/repos/router-for-me/CLIProxyAPI/releases/latest)"
+  cliproxy_tag="$(jq -r '.tag_name' <<< "$latest_json")"
+fi
+
+if [[ -z "$cliproxy_tag" || "$cliproxy_tag" == "null" ]]; then
+  echo "Could not resolve CLIProxyAPI release tag" >&2
+  exit 1
+fi
+
+release_json="$(curl -fsSL "https://api.github.com/repos/router-for-me/CLIProxyAPI/releases/tags/$cliproxy_tag")"
+
+asset_regex="^CLIProxyAPI_.+_linux_${asset_arch}\\.tar\\.gz$"
+asset_name="$(jq -r --arg regex "$asset_regex" '.assets[] | select(.name | test($regex)) | .name' <<< "$release_json" | head -n 1)"
+asset_url="$(jq -r --arg regex "$asset_regex" '.assets[] | select(.name | test($regex)) | .browser_download_url' <<< "$release_json" | head -n 1)"
+if [[ -z "$asset_name" || "$asset_name" == "null" || -z "$asset_url" || "$asset_url" == "null" ]]; then
+  echo "Could not find CLIProxyAPI Linux asset for $asset_arch in $cliproxy_tag" >&2
+  jq -r '.assets[].name' <<< "$release_json" >&2
+  exit 1
+fi
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+echo "Downloading $asset_name"
+curl -fL --retry 3 --retry-delay 5 -o "$work_dir/$asset_name" "$asset_url"
+curl -fsSL "https://github.com/router-for-me/CLIProxyAPI/releases/download/$cliproxy_tag/checksums.txt" -o "$work_dir/cliproxy-checksums.txt"
+(cd "$work_dir" && awk -v name="$asset_name" '$2 == name { print }' cliproxy-checksums.txt | sha256sum -c -)
+tar -xzf "$work_dir/$asset_name" -C "$work_dir"
+
+binary_path="$(find "$work_dir" -type f \( -name CLIProxyAPI -o -name cli-proxy-api -o -name CLIProxyAPIPlus -o -name cli-proxy-api-plus \) | head -n 1)"
+if [[ -z "$binary_path" ]]; then
+  binary_path="$(find "$work_dir" -type f -perm /111 | head -n 1)"
+fi
+if [[ -z "$binary_path" ]]; then
+  echo "Could not find CLIProxyAPI binary in $asset_name" >&2
+  tar -tf "$work_dir/$asset_name" >&2
+  exit 1
+fi
+
+cp packaging/linux/vibeproxy "$package_root/usr/bin/vibeproxy"
+cp "$binary_path" "$package_root/usr/lib/vibeproxy/cli-proxy-api-plus"
+chmod 0755 "$package_root/usr/bin/vibeproxy" "$package_root/usr/lib/vibeproxy/cli-proxy-api-plus"
+
+nfpm_bin="${NFPM_BIN:-}"
+if [[ -z "$nfpm_bin" ]]; then
+  if command -v nfpm >/dev/null 2>&1; then
+    nfpm_bin="$(command -v nfpm)"
+  else
+    nfpm_tag="v$nfpm_version"
+    nfpm_json="$(curl -fsSL "https://api.github.com/repos/goreleaser/nfpm/releases/tags/$nfpm_tag")"
+    nfpm_asset="nfpm_${nfpm_version}_Linux_${nfpm_host_arch}.tar.gz"
+    nfpm_url="$(jq -r --arg name "$nfpm_asset" '.assets[] | select(.name == $name) | .browser_download_url' <<< "$nfpm_json")"
+    if [[ -z "$nfpm_url" || "$nfpm_url" == "null" ]]; then
+      echo "Could not find nFPM asset $nfpm_asset" >&2
+      jq -r '.assets[].name' <<< "$nfpm_json" >&2
+      exit 1
+    fi
+    mkdir -p "$cache_dir/nfpm-$nfpm_version"
+    curl -fL --retry 3 --retry-delay 5 -o "$work_dir/$nfpm_asset" "$nfpm_url"
+    curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/$nfpm_tag/checksums.txt" -o "$work_dir/nfpm-checksums.txt"
+    (cd "$work_dir" && awk -v name="$nfpm_asset" '$2 == name { print }' nfpm-checksums.txt | sha256sum -c -)
+    tar -xzf "$work_dir/$nfpm_asset" -C "$cache_dir/nfpm-$nfpm_version"
+    nfpm_bin="$cache_dir/nfpm-$nfpm_version/nfpm"
+  fi
+fi
+
+export VERSION="$version"
+export RELEASE="$release"
+export NFPM_ARCH="$nfpm_arch"
+
+deb_target="$dist_dir/VibeProxy-linux-$nfpm_arch.deb"
+rpm_target="$dist_dir/VibeProxy-linux-$nfpm_arch.rpm"
+nfpm_config="$work_dir/nfpm.yaml"
+sed "s#__LINUX_PACKAGE_ROOT__#$package_root#g" packaging/linux/nfpm.yaml > "$nfpm_config"
+
+"$nfpm_bin" pkg --config "$nfpm_config" --packager deb --target "$deb_target"
+"$nfpm_bin" pkg --config "$nfpm_config" --packager rpm --target "$rpm_target"
+
+(cd "$dist_dir" && sha256sum "$(basename "$deb_target")" "$(basename "$rpm_target")" > "VibeProxy-linux-$nfpm_arch.sha256")
+
+echo "Created:"
+ls -lh "$deb_target" "$rpm_target" "$dist_dir/VibeProxy-linux-$nfpm_arch.sha256"


### PR DESCRIPTION
## Summary

- add `scripts/package-linux.sh` to build Linux `.deb` and `.rpm` packages for amd64 and arm64
- package the CLIProxyAPI backend with `/usr/bin/vibeproxy`, default config, docs, and a user-level systemd service
- wire Linux package artifacts into the release workflow and attach them to GitHub releases
- verify downloaded CLIProxyAPI and nFPM release assets with upstream checksums
- keep Linux release checksums relative so downloaded/copied artifacts validate correctly

## Verification

- `VERSION=1.8.218 CLIPROXY_VERSION=7.2.49 ARCH=amd64 scripts/package-linux.sh`
- `VERSION=1.8.218 CLIPROXY_VERSION=7.2.49 ARCH=arm64 scripts/package-linux.sh`
- `cd dist && sha256sum -c VibeProxy-linux-amd64.sha256 VibeProxy-linux-arm64.sha256`
- copied/tampered package checksum check fails as expected
- isolated `.deb` and `.rpm` roots contain expected files and wrapper reaches CLIProxyAPI help
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`
- `bash -n scripts/package-linux.sh packaging/linux/vibeproxy`
- `git diff --check`

## Review

Five-lane review rerun passed after fixes: gate, QA, code quality, security, and context mining all approved with no blocking issues.
