### PR TITLE
fix: notarize and staple release DMGs so Gatekeeper accepts them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,39 @@ jobs:
             codesign -dv "VibeProxy-${{ matrix.arch }}.dmg" || echo "⚠️ DMG not signed (non-fatal)"
           fi
 
+      - name: Notarize DMG
+        run: |
+          if [ -f "VibeProxy-${{ matrix.arch }}.dmg" ]; then
+            echo "Submitting DMG for notarization..."
+            SUBMIT_OUTPUT=$(xcrun notarytool submit "VibeProxy-${{ matrix.arch }}.dmg" \
+              --apple-id "${{ secrets.APPLE_ID }}" \
+              --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+              --password "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}" \
+              --wait --output-format json)
+
+            echo "$SUBMIT_OUTPUT"
+            SUBMISSION_ID=$(echo "$SUBMIT_OUTPUT" | jq -r '.id')
+            STATUS=$(echo "$SUBMIT_OUTPUT" | jq -r '.status')
+
+            if [ "$STATUS" != "Accepted" ]; then
+              echo "❌ DMG notarization failed with status: $STATUS"
+              echo "📋 Getting detailed log..."
+              xcrun notarytool log "$SUBMISSION_ID" \
+                --apple-id "${{ secrets.APPLE_ID }}" \
+                --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+                --password "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}"
+              exit 1
+            fi
+
+            echo "✅ DMG notarization succeeded! Stapling ticket..."
+            xcrun stapler staple "VibeProxy-${{ matrix.arch }}.dmg"
+            xcrun stapler validate "VibeProxy-${{ matrix.arch }}.dmg"
+            spctl --assess --type open --context context:primary-signature -v "VibeProxy-${{ matrix.arch }}.dmg"
+            echo "✅ DMG successfully notarized and stapled!"
+          else
+            echo "⚠️ DMG not found, skipping DMG notarization"
+          fi
+
       - name: Create ZIP archive
         run: |
           ditto -c -k --sequesterRsrc --keepParent "VibeProxy.app" "VibeProxy-${{ matrix.arch }}.zip"


### PR DESCRIPTION
## Summary
In `.github/workflows/release.yml`, add a "Notarize DMG" step in the `build-signed` job immediately after "Create DMG" and before "Create ZIP archive" / "Calculate checksums" (ordering matters: stapling modifies the DMG, so the sha256 must be computed after stapling - the existing step order already ensures this). The new step, guarded by `if [ -f "VibeProxy-${{ matrix.arch }}.dmg" ]` to match the workflow's existing non-fatal DMG handling, runs `xcrun notarytool submit "VibeProxy-${{ matrix.arch }}.dmg" --apple-id ... --team-id ...

## Why this matters
A user downloaded VibeProxy-arm64.dmg from the official releases and found that while the app bundle inside is correctly notarized and stapled (`spctl --assess --type execute` accepts it), the DMG itself is only codesigned, not notarized: `spctl --assess --type open --context context:primary-signature` rejects it with "Unnotarized Developer ID" and `xcrun stapler validate` confirms no ticket is stapled. The release notes claim "Code Signed & Notarized - No Gatekeeper warnings", so the DMG artifact contradicts the stated guarantee. Root cause is visible in `.github/workflows/release.yml`: the "Notarize App" step submits and staples only `VibeProxy.app`; the subsequent "Create DMG" step codesigns the DMG via create-dmg's `--codesign` flag but never submits the DMG to notarytool or staples it.

See https://github.com/automazeio/vibeproxy/issues/398.

## Testing
- Happy path: tag-triggered release run produces VibeProxy-arm64.dmg and VibeProxy-x86_64.dmg that pass `xcrun stapler validate` and `spctl --assess --type open --context context:primary-signature` (verified in-workflow by the new validate/assess commands; workflow YAML validated locally with actionlint/yamllint since CI secrets cannot be exercised from a fork). - Edge case: create-dmg fails and no DMG exists (the step uses `|| true`) - the notarize step's existence guard skips cleanly instead of erroring on a missing file. - Error path: notarytool returns a non-Accepted status for the DMG - the step prints the notarytool log for the submission id and exits 1, failing the release rather than shipping an unnotarized DMG. - Regression guard: sha256 files still match the final (stapled) DMG bytes because "Calculate checksums" runs after the new notarize/staple step.

Fixes #398
