### PR TITLE
docs(readme): document persistent user configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,32 @@ When you click "Add Account" for Z.AI GLM:
 - **Menu Bar Icon**: Shows active/inactive state
 - **Launch at Login**: Toggle to start VibeProxy automatically
 
+### Advanced Configuration
+
+VibeProxy supports persistent [CLIProxyAPIPlus](https://github.com/router-for-me/CLIProxyAPIPlus) overrides in:
+
+```text
+~/.cli-proxy-api/config.yaml
+```
+
+VibeProxy merges this user-owned file with its bundled defaults, writes the effective runtime configuration to `~/.cli-proxy-api/merged-config.yaml`, and reloads changes automatically. Put custom settings in `config.yaml`; do not edit `merged-config.yaml` directly because VibeProxy regenerates it.
+
+For example, supported GPT models can default to concise responses by adding an OpenAI Responses API verbosity rule:
+
+```yaml
+payload:
+  default:
+    - models:
+        - name: "gpt-*"
+      protocol: "codex"
+      params:
+        "text.verbosity": "low"
+```
+
+`default` only supplies the value when the client does not already send one. Use `override` instead if the proxy should always enforce the configured value. Supported verbosity values are `low`, `medium`, and `high`.
+
+After saving the file, VibeProxy regenerates its runtime configuration and applies the change without an application restart.
+
 ## Requirements
 
 - macOS 13.0 (Ventura) or later


### PR DESCRIPTION
## Summary

- document `~/.cli-proxy-api/config.yaml` as the persistent user-owned override file
- explain that VibeProxy generates `merged-config.yaml` and that users should not edit it directly
- add a tested Codex `text.verbosity: low` payload-default example
- clarify `default` versus `override` behavior and automatic reloads

## Verification

- `git diff --check`
- README fence and example assertions
- manually verified with VibeProxy 1.8.243 that editing `config.yaml` regenerated `merged-config.yaml` without restarting and that a request omitting `text.verbosity` returned `verbosity: low`