### PR TITLE
Restore Amp WebSocket and classic local-provider compatibility

### DIFF
--- a/AMPCODE_SETUP.md
+++ b/AMPCODE_SETUP.md
@@ -1,157 +1,120 @@
 # Amp CLI Setup Guide
 
-This guide explains how to configure Amp CLI to work with VibeProxy, enabling you to use your existing subscriptions (Claude Max, ChatGPT Plus, Gemini) through Amp CLI.
+VibeProxy supports **Amp classic mode only** for local model inference. The current default Amp CLI (Amp Neo) runs inference in Amp's cloud actor and does not send model requests to `localhost`, so VibeProxy cannot redirect Neo inference to your local subscriptions.
 
-## Overview
-
-VibeProxy integrates with Amp CLI by:
-- Routing Amp login directly to ampcode.com (preserves OAuth cookies)
-- Routing model requests through CLIProxyAPI (uses your local subscriptions)
-- **No fallback** - you must authenticate the providers you want to use
+To avoid Amp credit usage, run the pinned classic CLI shown below. Do not use the current default `amp` command for inference through VibeProxy.
 
 ## Prerequisites
 
 - VibeProxy installed and running
-- Amp CLI installed (`amp --version` to verify)
-- Active subscription (Claude Max, ChatGPT Plus, or Gemini)
+- Node.js with `npx`
+- At least one provider authenticated in VibeProxy (Claude, ChatGPT/Codex, or Gemini)
 
-## Setup
-
-### 1. Configure Amp URL
+## 1. Point Amp at VibeProxy
 
 ```bash
 mkdir -p ~/.config/amp
-echo '{"amp.url": "http://localhost:8317"}' > ~/.config/amp/settings.json
+printf '%s\n' '{"amp.url": "http://localhost:8317"}' > ~/.config/amp/settings.json
 ```
 
-### 2. Authenticate Your Providers (Required)
+## 2. Authenticate local providers
 
-You must authenticate at least one provider to use Amp through VibeProxy:
+Use VibeProxy's provider controls, or run the bundled backend login command for the provider you need:
 
 ```bash
-# Claude (Anthropic) - uses your Claude Max/Pro subscription
+# Claude Max/Pro
 /Applications/VibeProxy.app/Contents/Resources/cli-proxy-api-plus \
   -config /Applications/VibeProxy.app/Contents/Resources/config.yaml \
   -claude-login
 
-# ChatGPT (OpenAI) - uses your ChatGPT Plus/Pro subscription
+# ChatGPT Plus/Pro (Codex OAuth)
 /Applications/VibeProxy.app/Contents/Resources/cli-proxy-api-plus \
   -config /Applications/VibeProxy.app/Contents/Resources/config.yaml \
   -codex-login
 
-# Gemini (Google) - uses your Google AI subscription
+# Gemini
 /Applications/VibeProxy.app/Contents/Resources/cli-proxy-api-plus \
   -config /Applications/VibeProxy.app/Contents/Resources/config.yaml \
   -login
 ```
 
-### 3. Login to Amp (Optional)
+Restart VibeProxy after authenticating from the command line.
 
-If you want to use Amp's management features:
-
-```bash
-amp login
-```
-
-Your browser will open to ampcode.com for authentication.
-
-### 4. Restart VibeProxy
-
-Quit and relaunch VibeProxy from the menu bar.
-
-### 5. Test
+## 3. Run the pinned classic CLI
 
 ```bash
-amp "Say hello"
+npx -y @ampcode/cli@0.0.1779896748-g596c49 --take-me-back "Say hello"
 ```
 
-## How It Works
+For a convenient stable command, create a wrapper:
+
+```bash
+mkdir -p ~/.local/bin
+cat > ~/.local/bin/amp-classic <<'EOF'
+#!/bin/sh
+exec npx -y @ampcode/cli@0.0.1779896748-g596c49 --take-me-back "$@"
+EOF
+chmod +x ~/.local/bin/amp-classic
+```
+
+Then use:
+
+```bash
+amp-classic "Say hello"
+```
+
+If `~/.local/bin` is not already on your `PATH`, add it before using the short command.
+
+Use the same pinned wrapper for Amp management commands such as login if needed. Do not substitute the latest `amp` binary: current Amp Neo is not compatible with local inference interception.
+
+The current Amp cloud API rejects classic-format thread uploads. VibeProxy acknowledges those uploads locally so classic commands can exit cleanly; those threads are not synchronized to ampcode.com.
+
+## How routing works
 
 ```text
-Amp CLI
+Pinned Amp classic CLI
   │
   ▼
-http://localhost:8317 (VibeProxy)
+http://localhost:8317 (VibeProxy ThinkingProxy)
   │
-  ├─► /auth/cli-login ──────────► https://ampcode.com (direct redirect)
-  │
-  ├─► /provider/* ──────────────► CLIProxyAPI:8318
+  ├─► /api/provider/anthropic/v1/* ─► /v1/*
+  ├─► /api/provider/openai/v1/*    ─► /v1/*
+  ├─► /api/provider/google/v1beta/* ─► /v1beta/*
+  ├─► Google v1beta1 publisher paths ─► /v1beta/models/*
   │                                      │
-  │                               Local OAuth token?
-  │                                      │
-  │                               ┌──────┴──────┐
-  │                               │             │
-  │                              YES           NO
-  │                               │             │
-  │                         Use your        ERROR
-  │                         subscription   (auth_unavailable)
+  │                                      ▼
+  │                               CLIProxyAPI:8318
+  │                               (local provider OAuth)
   │
-  └─► /api/* (management) ──────► https://ampcode.com
+  ├─► /auth/cli-login ─────────────► https://ampcode.com
+  └─► Amp management requests ─────► https://ampcode.com
 ```
 
-## Provider Priority
+The path compatibility mapping is needed because the bundled CLIProxyAPIPlus no longer registers its old Amp-specific `/api/provider/*` routes, while its generic Anthropic, OpenAI, and Gemini endpoints remain available.
 
-When logged into multiple providers (Claude, ChatGPT, Gemini, etc.), Amp may pick models from any of them. Use **Provider Priority** to control which providers are active.
+## Provider controls
 
-### Enable/Disable Providers
-
-In VibeProxy Settings, each provider has a toggle switch:
-- **Enabled** (default) - Provider's models are available to Amp
-- **Disabled** - Provider's models are excluded from Amp
-
-Changes apply instantly via hot reload - no restart needed.
-
-### Use Cases
-
-- **Single provider mode** - Disable all but one provider to ensure Amp always uses that provider
-- **Avoid rate limits** - Disable providers you've hit rate limits on
-- **Testing** - Quickly switch between providers to compare responses
-
-### Notes
-
-- When all providers are disabled, Amp falls back to its free tier (rate limited)
-- Provider toggles only affect model availability, not authentication status
-- You remain logged into disabled providers and can re-enable them anytime
+VibeProxy's provider toggles control which locally authenticated providers and models CLIProxyAPI exposes. Disabling a provider does **not** make Amp Neo fall back through VibeProxy; Neo inference remains cloud-hosted and unsupported. If classic mode reports `auth_unavailable: no auth available`, authenticate or re-enable the provider needed by the selected model.
 
 ## Troubleshooting
 
-### "auth_unavailable: no auth available"
+### Requests do not appear in VibeProxy logs
 
-You haven't authenticated the provider for the model you're trying to use.
+Confirm the command includes both the pinned package version and `--take-me-back`. The current default Amp Neo client does not send inference requests through VibeProxy.
 
-**Solution:** Run the appropriate login command:
-- For Claude models: `-claude-login`
-- For GPT models: `-codex-login`
-- For Gemini models: `-login`
+### `auth_unavailable: no auth available`
 
-Then restart VibeProxy.
+Authenticate the provider required by the requested model, then restart VibeProxy if login was performed with the backend command.
 
-### OAuth token expired
+### Amp provider request returns 404
 
-Re-authenticate the provider:
+Confirm VibeProxy is running on port 8317 and the client is configured with `"amp.url": "http://localhost:8317"`. The ThinkingProxy compatibility layer maps classic Amp provider paths to the backend's generic endpoints.
 
-```bash
-# Check token files
-ls -la ~/.cli-proxy-api/*.json
+### Login fails in the browser
 
-# Re-login (example for Claude)
-/Applications/VibeProxy.app/Contents/Resources/cli-proxy-api-plus \
-  -config /Applications/VibeProxy.app/Contents/Resources/config.yaml \
-  -claude-login
-```
+Make sure VibeProxy is running before invoking login through the pinned classic wrapper.
 
-### Login fails in browser
-
-Make sure VibeProxy is running before attempting `amp login`.
-
-## Benefits
-
-- **Use your subscriptions** - Claude Max, ChatGPT Plus, Gemini work through Amp
-- **No surprise charges** - No fallback to Amp credits
-- **Full transparency** - Clear error if provider not authenticated
-- **One proxy** - Factory and Amp share the same setup
-
-## Additional Resources
+## Additional resources
 
 - [Amp CLI Documentation](https://ampcode.com/manual)
 - [Factory Setup Guide](FACTORY_SETUP.md)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ app: ## Create the .app bundle
 install: app ## Build and install to /Applications
 	@echo "📲 Installing to /Applications..."
 	@rm -rf "/Applications/VibeProxy.app"
-	@cp -r "VibeProxy.app" /Applications/
+	@cp -R "VibeProxy.app" /Applications/
+	@codesign --verify --deep --strict "/Applications/VibeProxy.app"
 	@echo "✅ Installed to /Applications/VibeProxy.app"
 
 run: app ## Build and run the app

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -30,16 +30,23 @@ enum AmpUpstream: Equatable {
 struct AmpRequestRouter {
     static func upstream(
         method: String,
+        path: String,
         version: String,
         headers: [(String, String)]
     ) -> AmpUpstream {
         let connectionTokens = headerTokens(named: "connection", in: headers)
         let upgradeTokens = headerTokens(named: "upgrade", in: headers)
+        let websocketKeys = headerValues(named: "sec-websocket-key", in: headers)
+        let websocketVersions = headerValues(named: "sec-websocket-version", in: headers)
 
         if method.uppercased() == "GET",
+           path.hasPrefix("/actors/gateway/"),
            version == "HTTP/1.1",
            connectionTokens.contains("upgrade"),
-           upgradeTokens.contains("websocket") {
+           upgradeTokens.contains("websocket"),
+           websocketKeys.count == 1,
+           Data(base64Encoded: websocketKeys[0])?.count == 16,
+           websocketVersions == ["13"] {
             return .actors
         }
         return .management
@@ -53,6 +60,15 @@ struct AmpRequestRouter {
             .filter { $0.0.caseInsensitiveCompare(expectedName) == .orderedSame }
             .flatMap { $0.1.split(separator: ",") }
             .map { $0.trimmingCharacters(in: .whitespaces).lowercased() })
+    }
+
+    private static func headerValues(
+        named expectedName: String,
+        in headers: [(String, String)]
+    ) -> [String] {
+        headers
+            .filter { $0.0.caseInsensitiveCompare(expectedName) == .orderedSame }
+            .map { $0.1.trimmingCharacters(in: .whitespaces) }
     }
 }
 
@@ -73,11 +89,26 @@ struct AmpWebSocketHandshake {
         if path.hasPrefix("/actors/gateway/"), let rivetToken {
             upstreamPath = addingRivetToken(rivetToken, to: path)
         }
+
+        var excludedHeaders: Set<String> = [
+            "connection", "content-length", "host", "keep-alive", "proxy-authorization",
+            "proxy-connection", "te", "trailer", "transfer-encoding", "upgrade",
+        ]
+        for value in headers where value.0.caseInsensitiveCompare("connection") == .orderedSame {
+            excludedHeaders.formUnion(
+                value.1.split(separator: ",").map {
+                    $0.trimmingCharacters(in: .whitespaces).lowercased()
+                }
+            )
+        }
+
         var request = "\(method) \(upstreamPath) \(version)\r\n"
-        for (name, value) in headers where name.lowercased() != "host" {
+        for (name, value) in headers where !excludedHeaders.contains(name.lowercased()) {
             request += "\(name): \(value)\r\n"
         }
-        request += "Host: \(host)\r\n\r\n"
+        request += "Host: \(host)\r\n"
+        request += "Connection: Upgrade\r\n"
+        request += "Upgrade: websocket\r\n\r\n"
         guard var data = request.data(using: .utf8) else { return nil }
         data.append(initialPayload)
         return data
@@ -432,7 +463,7 @@ class ThinkingProxy {
         let isCliProxyPath = rewrittenPath.starts(with: "/v1/") || rewrittenPath.starts(with: "/api/v1/")
         if !isProviderPath && !isCliProxyPath {
             let ampPath = rewrittenPath
-            switch AmpRequestRouter.upstream(method: method, version: httpVersion, headers: headers) {
+            switch AmpRequestRouter.upstream(method: method, path: ampPath, version: httpVersion, headers: headers) {
             case .management:
                 guard let bodyString = String(data: bodyData, encoding: .utf8) else {
                     sendError(to: connection, statusCode: 400, message: "Invalid request body")

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -22,6 +22,191 @@ struct VercelGatewayConfig {
     var isActive: Bool { enabled && !apiKey.isEmpty }
 }
 
+enum AmpUpstream: Equatable {
+    case management
+    case actors
+}
+
+struct AmpRequestRouter {
+    static func upstream(
+        method: String,
+        version: String,
+        headers: [(String, String)]
+    ) -> AmpUpstream {
+        let connectionTokens = headerTokens(named: "connection", in: headers)
+        let upgradeTokens = headerTokens(named: "upgrade", in: headers)
+
+        if method.uppercased() == "GET",
+           version == "HTTP/1.1",
+           connectionTokens.contains("upgrade"),
+           upgradeTokens.contains("websocket") {
+            return .actors
+        }
+        return .management
+    }
+
+    private static func headerTokens(
+        named expectedName: String,
+        in headers: [(String, String)]
+    ) -> Set<String> {
+        Set(headers
+            .filter { $0.0.caseInsensitiveCompare(expectedName) == .orderedSame }
+            .flatMap { $0.1.split(separator: ",") }
+            .map { $0.trimmingCharacters(in: .whitespaces).lowercased() })
+    }
+}
+
+struct AmpWebSocketHandshake {
+    static let host = "ampcode.com"
+    // Public Rivet routing token used by Amp's cloud actor endpoint.
+    static let rivetPublicToken = "pk_9tm4qz3zrMerdZXTlBRLRsmJIzSQIPH24meKBqiL6vVpscTvc4w1YPiBgymXf9Az"
+
+    static func request(
+        method: String,
+        path: String,
+        version: String,
+        headers: [(String, String)],
+        rivetToken: String? = rivetPublicToken,
+        initialPayload: Data = Data()
+    ) -> Data? {
+        var upstreamPath = path
+        if path.hasPrefix("/actors/gateway/"), let rivetToken {
+            upstreamPath = addingRivetToken(rivetToken, to: path)
+        }
+        var request = "\(method) \(upstreamPath) \(version)\r\n"
+        for (name, value) in headers where name.lowercased() != "host" {
+            request += "\(name): \(value)\r\n"
+        }
+        request += "Host: \(host)\r\n\r\n"
+        guard var data = request.data(using: .utf8) else { return nil }
+        data.append(initialPayload)
+        return data
+    }
+
+    private static func addingRivetToken(_ token: String, to path: String) -> String {
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "&=+#?")
+        guard let encodedToken = token.addingPercentEncoding(withAllowedCharacters: allowed) else {
+            return path
+        }
+
+        guard let queryMarker = path.firstIndex(of: "?") else {
+            return path + "?rvt-token=" + encodedToken
+        }
+
+        let queryStart = path.index(after: queryMarker)
+        let pathPrefix = path[...queryMarker]
+        let fields = path[queryStart...].split(separator: "&", omittingEmptySubsequences: false).map(String.init)
+        var tokenFields: [(index: Int, value: String, field: String)] = []
+
+        for index in fields.indices {
+            let field = fields[index]
+            let separator = field.firstIndex(of: "=")
+            let encodedName = separator.map { String(field[..<$0]) } ?? field
+            guard encodedName.removingPercentEncoding == "rvt-token" else { continue }
+
+            let value = separator.map { String(field[field.index(after: $0)...]) } ?? ""
+            tokenFields.append((index, value, field))
+        }
+
+        if let firstToken = tokenFields.first {
+            let canonicalField = tokenFields.first(where: { !$0.value.isEmpty })?.field
+                ?? "rvt-token=" + encodedToken
+            let tokenIndices = Set(tokenFields.map(\.index))
+            var canonicalFields: [String] = []
+            for index in fields.indices {
+                if index == firstToken.index {
+                    canonicalFields.append(canonicalField)
+                } else if !tokenIndices.contains(index) {
+                    canonicalFields.append(fields[index])
+                }
+            }
+            return String(pathPrefix) + canonicalFields.joined(separator: "&")
+        }
+
+        let separator = path.hasSuffix("?") || path.hasSuffix("&") ? "" : "&"
+        return path + separator + "rvt-token=" + encodedToken
+    }
+}
+
+enum HTTPStatusLine {
+    static func from(_ data: Data) -> String? {
+        guard let lineEnd = data.range(of: Data("\r\n".utf8)),
+              let line = String(data: data[..<lineEnd.lowerBound], encoding: .utf8),
+              line.hasPrefix("HTTP/") else {
+            return nil
+        }
+        return line
+    }
+}
+
+private final class BidirectionalTunnel {
+    private let first: NWConnection
+    private let second: NWConnection
+    private let lock = NSLock()
+    private var completedDirections = 0
+    private var failed = false
+
+    init(_ first: NWConnection, _ second: NWConnection) {
+        self.first = first
+        self.second = second
+    }
+
+    func start() {
+        pump(from: first, to: second)
+        pump(from: second, to: first)
+    }
+
+    private func pump(from source: NWConnection, to destination: NWConnection) {
+        source.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [self] data, _, isComplete, error in
+            if let error {
+                closeAfterFailure(error)
+                return
+            }
+
+            if data == nil && !isComplete {
+                pump(from: source, to: destination)
+                return
+            }
+
+            destination.send(content: data, isComplete: isComplete, completion: .contentProcessed { [self] error in
+                if let error {
+                    closeAfterFailure(error)
+                } else if isComplete {
+                    directionCompleted()
+                } else {
+                    pump(from: source, to: destination)
+                }
+            })
+        }
+    }
+
+    private func directionCompleted() {
+        lock.lock()
+        completedDirections += 1
+        let shouldClose = completedDirections == 2 && !failed
+        lock.unlock()
+
+        if shouldClose {
+            first.cancel()
+            second.cancel()
+        }
+    }
+
+    private func closeAfterFailure(_ error: NWError) {
+        lock.lock()
+        let shouldClose = !failed
+        failed = true
+        lock.unlock()
+
+        if shouldClose {
+            NSLog("[ThinkingProxy] WebSocket tunnel error: \(error)")
+            first.cancel()
+            second.cancel()
+        }
+    }
+}
+
 class ThinkingProxy {
     private var listener: NWListener?
     let proxyPort: UInt16 = 8317
@@ -38,6 +223,7 @@ class ThinkingProxy {
         static let headroomRatio = 0.1
         static let vercelGatewayHost = "ai-gateway.vercel.sh"
         static let anthropicVersion = "2023-06-01"
+        static let ampActorsHost = AmpWebSocketHandshake.host
     }
     
     /**
@@ -148,13 +334,13 @@ class ThinkingProxy {
             var newAccumulatedData = accumulatedData
             newAccumulatedData.append(data)
             
-            // Check if we have a complete HTTP request
-            if let requestString = String(data: newAccumulatedData, encoding: .utf8),
-               let headerEndRange = requestString.range(of: "\r\n\r\n") {
+            // Check if we have a complete HTTP header without decoding any
+            // WebSocket bytes that may already follow it.
+            if let headerEndRange = newAccumulatedData.range(of: Data("\r\n\r\n".utf8)),
+               let headerPart = String(data: newAccumulatedData[..<headerEndRange.upperBound], encoding: .utf8) {
                 
                 // Extract Content-Length if present
-                let headerEndIndex = requestString.distance(from: requestString.startIndex, to: headerEndRange.upperBound)
-                let headerPart = String(requestString.prefix(headerEndIndex))
+                let headerEndIndex = headerEndRange.upperBound
                 
                 if let contentLengthLine = headerPart.components(separatedBy: "\r\n").first(where: { $0.lowercased().starts(with: "content-length:") }) {
                     let contentLengthStr = contentLengthLine.components(separatedBy: ":")[1].trimmingCharacters(in: .whitespaces)
@@ -186,10 +372,12 @@ class ThinkingProxy {
      Processes the HTTP request, modifies it if needed, and forwards to CLIProxyAPI
      */
     private func processRequest(data: Data, connection: NWConnection) {
-        guard let requestString = String(data: data, encoding: .utf8) else {
+        guard let headerEndRange = data.range(of: Data("\r\n\r\n".utf8)),
+              let requestString = String(data: data[..<headerEndRange.upperBound], encoding: .utf8) else {
             sendError(to: connection, statusCode: 400, message: "Invalid request")
             return
         }
+        let bodyData = Data(data[headerEndRange.upperBound...])
         
         // Parse HTTP request
         let lines = requestString.components(separatedBy: "\r\n")
@@ -221,16 +409,6 @@ class ThinkingProxy {
             headers.append((name, value))
         }
         
-        // Find the body start
-        guard let bodyStartRange = requestString.range(of: "\r\n\r\n") else {
-            NSLog("[ThinkingProxy] Error: Could not find body separator in request")
-            sendError(to: connection, statusCode: 400, message: "Invalid request format - no body separator")
-            return
-        }
-        
-        let bodyStart = requestString.distance(from: requestString.startIndex, to: bodyStartRange.upperBound)
-        let bodyString = String(requestString[requestString.index(requestString.startIndex, offsetBy: bodyStart)...])
-        
         // Redirect Amp CLI login directly to ampcode.com to preserve auth state cookies
         if path.starts(with: "/auth/cli-login") || path.starts(with: "/api/auth/cli-login") {
             let loginPath = path.hasPrefix("/api/") ? String(path.dropFirst(4)) : path
@@ -254,8 +432,30 @@ class ThinkingProxy {
         let isCliProxyPath = rewrittenPath.starts(with: "/v1/") || rewrittenPath.starts(with: "/api/v1/")
         if !isProviderPath && !isCliProxyPath {
             let ampPath = rewrittenPath
-            NSLog("[ThinkingProxy] Amp management request detected, forwarding to ampcode.com: \(ampPath)")
-            forwardToAmp(method: method, path: ampPath, version: httpVersion, headers: headers, body: bodyString, originalConnection: connection)
+            switch AmpRequestRouter.upstream(method: method, version: httpVersion, headers: headers) {
+            case .management:
+                guard let bodyString = String(data: bodyData, encoding: .utf8) else {
+                    sendError(to: connection, statusCode: 400, message: "Invalid request body")
+                    return
+                }
+                NSLog("[ThinkingProxy] Amp management request detected, forwarding to ampcode.com: \(ampPath)")
+                forwardToAmp(method: method, path: ampPath, version: httpVersion, headers: headers, body: bodyString, originalConnection: connection)
+            case .actors:
+                NSLog("[ThinkingProxy] Amp actor WebSocket detected, forwarding to \(Config.ampActorsHost): \(ampPath)")
+                forwardAmpWebSocket(
+                    method: method,
+                    path: ampPath,
+                    version: httpVersion,
+                    headers: headers,
+                    initialPayload: bodyData,
+                    originalConnection: connection
+                )
+            }
+            return
+        }
+
+        guard let bodyString = String(data: bodyData, encoding: .utf8) else {
+            sendError(to: connection, statusCode: 400, message: "Invalid request body")
             return
         }
         
@@ -517,6 +717,105 @@ class ThinkingProxy {
         
         targetConnection.start(queue: .global(qos: .userInitiated))
     }
+
+    private func forwardAmpWebSocket(
+        method: String,
+        path: String,
+        version: String,
+        headers: [(String, String)],
+        initialPayload: Data,
+        originalConnection: NWConnection
+    ) {
+        guard let request = AmpWebSocketHandshake.request(
+            method: method,
+            path: path,
+            version: version,
+            headers: headers,
+            initialPayload: initialPayload
+        ) else {
+            sendError(to: originalConnection, statusCode: 400, message: "Invalid WebSocket handshake")
+            return
+        }
+
+        let parameters = NWParameters(tls: NWProtocolTLS.Options(), tcp: NWProtocolTCP.Options())
+        let endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(Config.ampActorsHost), port: 443)
+        let targetConnection = NWConnection(to: endpoint, using: parameters)
+
+        targetConnection.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                // From this point on, upgraded traffic is an opaque byte stream;
+                // it must never pass through Amp's HTTP response rewriting.
+                targetConnection.stateUpdateHandler = nil
+                targetConnection.send(content: request, completion: .contentProcessed { error in
+                    if let error {
+                        NSLog("[ThinkingProxy] WebSocket handshake send error: \(error)")
+                        targetConnection.cancel()
+                        originalConnection.cancel()
+                        return
+                    }
+
+                    self.receiveAmpWebSocketHandshakeResponse(
+                        from: targetConnection,
+                        originalConnection: originalConnection
+                    )
+                })
+            case .failed(let error):
+                NSLog("[ThinkingProxy] Connection to \(Config.ampActorsHost) failed: \(error)")
+                self.sendError(to: originalConnection, statusCode: 502, message: "Bad Gateway - Could not connect to Amp actors")
+                targetConnection.cancel()
+            default:
+                break
+            }
+        }
+
+        targetConnection.start(queue: .global(qos: .userInitiated))
+    }
+
+    private func receiveAmpWebSocketHandshakeResponse(
+        from targetConnection: NWConnection,
+        originalConnection: NWConnection
+    ) {
+        targetConnection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { data, _, isComplete, error in
+            if let error {
+                NSLog("[ThinkingProxy] WebSocket handshake receive error: \(error)")
+                targetConnection.cancel()
+                originalConnection.cancel()
+                return
+            }
+
+            guard let data, !data.isEmpty else {
+                if isComplete {
+                    targetConnection.cancel()
+                    originalConnection.cancel()
+                } else {
+                    self.receiveAmpWebSocketHandshakeResponse(
+                        from: targetConnection,
+                        originalConnection: originalConnection
+                    )
+                }
+                return
+            }
+
+            if let statusLine = HTTPStatusLine.from(data) {
+                NSLog("[ThinkingProxy] Amp actor handshake response: \(statusLine)")
+            }
+
+            originalConnection.send(content: data, isComplete: isComplete, completion: .contentProcessed { sendError in
+                if let sendError {
+                    NSLog("[ThinkingProxy] WebSocket handshake response send error: \(sendError)")
+                    targetConnection.cancel()
+                    originalConnection.cancel()
+                } else if isComplete {
+                    targetConnection.cancel()
+                    originalConnection.cancel()
+                } else {
+                    BidirectionalTunnel(originalConnection, targetConnection).start()
+                }
+            })
+        }
+    }
     
     /**
      Receives response from ampcode.com and rewrites Location headers to add /api/ prefix
@@ -612,7 +911,7 @@ class ThinkingProxy {
             }
         }
     }
-    
+
     /**
      Forwards Claude requests to Vercel AI Gateway (ai-gateway.vercel.sh)
      */

--- a/src/Sources/ThinkingProxy.swift
+++ b/src/Sources/ThinkingProxy.swift
@@ -27,6 +27,58 @@ enum AmpUpstream: Equatable {
     case actors
 }
 
+public enum AmpProviderRouteMapper {
+    public static func isCLIProxyPath(_ path: String) -> Bool {
+        path.hasPrefix("/v1/")
+            || path.hasPrefix("/api/v1/")
+            || path.hasPrefix("/v1beta/")
+            || path.hasPrefix("/api/v1beta/")
+    }
+
+    public static func cliProxyPath(for path: String) -> String {
+        for provider in ["anthropic", "openai"] {
+            let prefix = "/api/provider/\(provider)"
+            let suffix = String(path.dropFirst(prefix.count))
+            if path.hasPrefix(prefix + "/"), suffix.hasPrefix("/v1/") {
+                return suffix
+            }
+        }
+
+        let googlePrefix = "/api/provider/google"
+        guard path.hasPrefix(googlePrefix + "/") else { return path }
+        let suffix = String(path.dropFirst(googlePrefix.count))
+        if suffix.hasPrefix("/v1beta/") {
+            return suffix
+        }
+        if suffix.hasPrefix("/v1beta1/"), let modelsRange = suffix.range(of: "/models/") {
+            return "/v1beta/models/" + suffix[modelsRange.upperBound...]
+        }
+        return path
+    }
+}
+
+enum AmpClassicCompatibility {
+    static func shouldAcknowledgeLocally(method: String, path: String) -> Bool {
+        method.uppercased() == "POST" && path == "/api/internal?uploadThread"
+    }
+
+    static var acknowledgmentBody: Data {
+        Data(#"{"ok":true,"result":{}}"#.utf8)
+    }
+
+    static var acknowledgmentResponse: Data {
+        let body = acknowledgmentBody
+        let header = "HTTP/1.1 200 OK\r\n" +
+            "Content-Type: application/json\r\n" +
+            "Content-Length: \(body.count)\r\n" +
+            "Connection: close\r\n" +
+            "\r\n"
+        var response = Data(header.utf8)
+        response.append(body)
+        return response
+    }
+}
+
 struct AmpRequestRouter {
     static func upstream(
         method: String,
@@ -439,6 +491,15 @@ class ThinkingProxy {
             let value = String(line[valueStart...]).trimmingCharacters(in: .whitespaces)
             headers.append((name, value))
         }
+
+        if AmpClassicCompatibility.shouldAcknowledgeLocally(method: method, path: path) {
+            NSLog("[ThinkingProxy] Acknowledging Amp classic thread upload locally")
+            connection.send(
+                content: AmpClassicCompatibility.acknowledgmentResponse,
+                completion: .contentProcessed { _ in connection.cancel() }
+            )
+            return
+        }
         
         // Redirect Amp CLI login directly to ampcode.com to preserve auth state cookies
         if path.starts(with: "/auth/cli-login") || path.starts(with: "/api/auth/cli-login") {
@@ -456,11 +517,17 @@ class ThinkingProxy {
             rewrittenPath = "/api" + path
             NSLog("[ThinkingProxy] Rewriting Amp provider path: \(path) -> \(rewrittenPath)")
         }
+
+        let genericProviderPath = AmpProviderRouteMapper.cliProxyPath(for: rewrittenPath)
+        if genericProviderPath != rewrittenPath {
+            NSLog("[ThinkingProxy] Mapping Amp provider path: \(rewrittenPath) -> \(genericProviderPath)")
+            rewrittenPath = genericProviderPath
+        }
         
-        // Check if this is an Amp management request (anything not targeting provider or /v1)
+        // Check if this is an Amp management request (anything not targeting provider, /v1, or /v1beta)
         // Note: /provider/ paths are already rewritten to /api/provider/ above
         let isProviderPath = rewrittenPath.starts(with: "/api/provider/")
-        let isCliProxyPath = rewrittenPath.starts(with: "/v1/") || rewrittenPath.starts(with: "/api/v1/")
+        let isCliProxyPath = AmpProviderRouteMapper.isCLIProxyPath(rewrittenPath)
         if !isProviderPath && !isCliProxyPath {
             let ampPath = rewrittenPath
             switch AmpRequestRouter.upstream(method: method, path: ampPath, version: httpVersion, headers: headers) {

--- a/src/Tests/ThinkingProxyTests.swift
+++ b/src/Tests/ThinkingProxyTests.swift
@@ -2,6 +2,92 @@ import XCTest
 @testable import CLIProxyMenuBar
 
 final class ThinkingProxyTests: XCTestCase {
+    func testClassicThreadUploadIsAcknowledgedLocally() {
+        XCTAssertTrue(
+            AmpClassicCompatibility.shouldAcknowledgeLocally(
+                method: "POST",
+                path: "/api/internal?uploadThread"
+            )
+        )
+        XCTAssertFalse(
+            AmpClassicCompatibility.shouldAcknowledgeLocally(
+                method: "GET",
+                path: "/api/internal?uploadThread"
+            )
+        )
+        XCTAssertFalse(
+            AmpClassicCompatibility.shouldAcknowledgeLocally(
+                method: "POST",
+                path: "/api/internal?getUserInfo"
+            )
+        )
+    }
+
+    func testClassicThreadUploadAcknowledgmentMatchesInternalAPIEnvelope() throws {
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: AmpClassicCompatibility.acknowledgmentBody)
+                as? [String: Any]
+        )
+
+        XCTAssertEqual(object["ok"] as? Bool, true)
+        XCTAssertNotNil(object["result"] as? [String: Any])
+        XCTAssertNil(object["error"])
+    }
+
+    func testClassicThreadUploadAcknowledgmentIsACompleteHTTPResponse() throws {
+        let response = AmpClassicCompatibility.acknowledgmentResponse
+        let separator = try XCTUnwrap(response.range(of: Data("\r\n\r\n".utf8)))
+        let header = try XCTUnwrap(String(data: response[..<separator.lowerBound], encoding: .utf8))
+        let body = Data(response[separator.upperBound...])
+
+        XCTAssertTrue(header.hasPrefix("HTTP/1.1 200 OK\r\n"))
+        XCTAssertTrue(header.contains("Content-Type: application/json\r\n"))
+        XCTAssertTrue(header.contains("Content-Length: \(body.count)\r\n"))
+        XCTAssertTrue(header.contains("Connection: close"))
+        XCTAssertEqual(body, AmpClassicCompatibility.acknowledgmentBody)
+    }
+
+    func testMapsAmpAnthropicMessagesToGenericClaudeEndpoint() {
+        XCTAssertEqual(
+            AmpProviderRouteMapper.cliProxyPath(for: "/api/provider/anthropic/v1/messages"),
+            "/v1/messages"
+        )
+    }
+
+    func testMapsAmpOpenAIAndGoogleRoutesToGenericEndpoints() {
+        XCTAssertEqual(
+            AmpProviderRouteMapper.cliProxyPath(for: "/api/provider/openai/v1/responses"),
+            "/v1/responses"
+        )
+        XCTAssertEqual(
+            AmpProviderRouteMapper.cliProxyPath(for: "/api/provider/google/v1beta/models/gemini-2.5-pro:generateContent?alt=sse"),
+            "/v1beta/models/gemini-2.5-pro:generateContent?alt=sse"
+        )
+        XCTAssertEqual(
+            AmpProviderRouteMapper.cliProxyPath(for: "/api/provider/google/v1beta1/publishers/google/models/gemini-3-pro-preview:streamGenerateContent?alt=sse"),
+            "/v1beta/models/gemini-3-pro-preview:streamGenerateContent?alt=sse"
+        )
+    }
+
+    func testDoesNotRewriteUnknownOrProviderLookalikeRoutes() {
+        XCTAssertEqual(
+            AmpProviderRouteMapper.cliProxyPath(for: "/api/provider/groq/v1/chat/completions"),
+            "/api/provider/groq/v1/chat/completions"
+        )
+        XCTAssertEqual(
+            AmpProviderRouteMapper.cliProxyPath(for: "/api/provider/anthropic-proxy/v1/messages"),
+            "/api/provider/anthropic-proxy/v1/messages"
+        )
+    }
+
+    func testMappedGeminiPathRemainsLocalCLIProxyTraffic() {
+        let path = AmpProviderRouteMapper.cliProxyPath(
+            for: "/api/provider/google/v1beta/models/gemini-2.5-pro:generateContent"
+        )
+
+        XCTAssertTrue(AmpProviderRouteMapper.isCLIProxyPath(path))
+    }
+
     func testActorWebSocketAddsAmpRivetPublicTokenToUpstreamPath() throws {
         let handshake = try XCTUnwrap(AmpWebSocketHandshake.request(
             method: "GET",

--- a/src/Tests/ThinkingProxyTests.swift
+++ b/src/Tests/ThinkingProxyTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import CLIProxyMenuBar
+
+final class ThinkingProxyTests: XCTestCase {
+    func testActorWebSocketAddsAmpRivetPublicTokenToUpstreamPath() throws {
+        let handshake = try XCTUnwrap(AmpWebSocketHandshake.request(
+            method: "GET",
+            path: "/actors/gateway/threadActor/websocket/?rvt-namespace=default",
+            version: "HTTP/1.1",
+            headers: [("Upgrade", "websocket")],
+            rivetToken: "pk_test"
+        ))
+        let request = try XCTUnwrap(String(data: handshake, encoding: .utf8))
+
+        XCTAssertTrue(request.hasPrefix("GET /actors/gateway/threadActor/websocket/?rvt-namespace=default&rvt-token=pk_test HTTP/1.1\r\n"))
+    }
+
+    func testActorWebSocketDoesNotMistakeAnotherQueryValueForRivetToken() throws {
+        let handshake = try XCTUnwrap(AmpWebSocketHandshake.request(
+            method: "GET",
+            path: "/actors/gateway/threadActor/websocket/?note=rvt-token=",
+            version: "HTTP/1.1",
+            headers: [("Upgrade", "websocket")],
+            rivetToken: "pk_test"
+        ))
+        let request = try XCTUnwrap(String(data: handshake, encoding: .utf8))
+
+        XCTAssertTrue(request.hasPrefix("GET /actors/gateway/threadActor/websocket/?note=rvt-token=&rvt-token=pk_test HTTP/1.1\r\n"))
+    }
+
+    func testActorWebSocketReplacesBlankRivetToken() throws {
+        let handshake = try XCTUnwrap(AmpWebSocketHandshake.request(
+            method: "GET",
+            path: "/actors/gateway/threadActor/websocket/?rvt-token=&rvt-key=thread",
+            version: "HTTP/1.1",
+            headers: [("Upgrade", "websocket")],
+            rivetToken: "pk_test"
+        ))
+        let request = try XCTUnwrap(String(data: handshake, encoding: .utf8))
+
+        XCTAssertTrue(request.hasPrefix("GET /actors/gateway/threadActor/websocket/?rvt-token=pk_test&rvt-key=thread HTTP/1.1\r\n"))
+    }
+
+    func testActorWebSocketPreservesExistingRivetToken() throws {
+        let handshake = try XCTUnwrap(AmpWebSocketHandshake.request(
+            method: "GET",
+            path: "/actors/gateway/threadActor/websocket/?rvt-token=caller-token&rvt-key=thread",
+            version: "HTTP/1.1",
+            headers: [("Upgrade", "websocket")],
+            rivetToken: "pk_test"
+        ))
+        let request = try XCTUnwrap(String(data: handshake, encoding: .utf8))
+
+        XCTAssertTrue(request.hasPrefix("GET /actors/gateway/threadActor/websocket/?rvt-token=caller-token&rvt-key=thread HTTP/1.1\r\n"))
+        XCTAssertFalse(request.contains("rvt-token=pk_test"))
+    }
+
+    func testActorWebSocketCanonicalizesDuplicateRivetTokens() throws {
+        let handshake = try XCTUnwrap(AmpWebSocketHandshake.request(
+            method: "GET",
+            path: "/actors/gateway/threadActor/websocket/?rvt-token=&rvt-token=caller-token&rvt-key=thread",
+            version: "HTTP/1.1",
+            headers: [("Upgrade", "websocket")],
+            rivetToken: "pk_test"
+        ))
+        let request = try XCTUnwrap(String(data: handshake, encoding: .utf8))
+
+        XCTAssertTrue(request.hasPrefix("GET /actors/gateway/threadActor/websocket/?rvt-token=caller-token&rvt-key=thread HTTP/1.1\r\n"))
+        XCTAssertEqual(request.components(separatedBy: "rvt-token=").count - 1, 1)
+        XCTAssertFalse(request.contains("rvt-token=pk_test"))
+    }
+
+
+    func testWebSocketUpgradeRoutesToAmpActors() throws {
+        let headers = [
+            ("Connection", "keep-alive, Upgrade"),
+            ("Upgrade", "websocket"),
+            ("Authorization", "Bearer amp-token"),
+        ]
+
+        XCTAssertEqual(
+            AmpRequestRouter.upstream(method: "GET", version: "HTTP/1.1", headers: headers),
+            .actors
+        )
+
+        let firstFrame = Data([0x82, 0x02, 0xFF, 0x00])
+        let handshake = try XCTUnwrap(AmpWebSocketHandshake.request(
+            method: "GET",
+            path: "/v2/actors/thread?connection=abc",
+            version: "HTTP/1.1",
+            headers: headers + [
+                ("Host", "localhost:8317"),
+                ("Sec-WebSocket-Key", "key=="),
+                ("Origin", "http://localhost:8317"),
+            ],
+            initialPayload: firstFrame
+        ))
+
+        let headerLength = try XCTUnwrap(handshake.range(of: Data("\r\n\r\n".utf8))?.upperBound)
+        let header = try XCTUnwrap(String(data: handshake[..<headerLength], encoding: .utf8))
+        XCTAssertTrue(header.contains("Authorization: Bearer amp-token\r\n"))
+        XCTAssertTrue(header.contains("Sec-WebSocket-Key: key==\r\n"))
+        XCTAssertTrue(header.contains("Origin: http://localhost:8317\r\n"))
+        XCTAssertTrue(header.contains("Host: ampcode.com\r\n"))
+        XCTAssertFalse(header.contains("Host: localhost:8317"))
+        XCTAssertEqual(Data(handshake[headerLength...]), firstFrame)
+    }
+
+    func testWebSocketRoutingCombinesDuplicateHeadersCaseInsensitively() {
+        let headers = [
+            ("Connection", "keep-alive"),
+            ("connection", "UPGRADE"),
+            ("Upgrade", "h2c"),
+            ("UPGRADE", "WebSocket"),
+        ]
+
+        XCTAssertEqual(
+            AmpRequestRouter.upstream(method: "get", version: "HTTP/1.1", headers: headers),
+            .actors
+        )
+    }
+
+    func testMalformedAndNonWebSocketUpgradesRemainManagementRequests() {
+        let cases: [(String, String, [(String, String)])] = [
+            ("POST", "HTTP/1.1", [("Connection", "Upgrade"), ("Upgrade", "websocket")]),
+            ("GET", "HTTP/1.0", [("Connection", "Upgrade"), ("Upgrade", "websocket")]),
+            ("GET", "HTTP/2.0", [("Connection", "Upgrade"), ("Upgrade", "websocket")]),
+            ("GET", "garbage", [("Connection", "Upgrade"), ("Upgrade", "websocket")]),
+            ("GET", "HTTP/1.1", [("Connection", "keep-alive"), ("Upgrade", "websocket")]),
+            ("GET", "HTTP/1.1", [("Connection", "Upgrade"), ("Upgrade", "h2c")]),
+        ]
+
+        for (method, version, headers) in cases {
+            XCTAssertEqual(
+                AmpRequestRouter.upstream(method: method, version: version, headers: headers),
+                .management
+            )
+        }
+    }
+
+    func testExtractsOnlyUpstreamHandshakeStatusLine() {
+        let response = Data(
+            "HTTP/1.1 403 Forbidden\r\nAuthorization: secret\r\n\r\n".utf8
+        )
+
+        XCTAssertEqual(HTTPStatusLine.from(response), "HTTP/1.1 403 Forbidden")
+    }
+}

--- a/src/Tests/ThinkingProxyTests.swift
+++ b/src/Tests/ThinkingProxyTests.swift
@@ -70,27 +70,54 @@ final class ThinkingProxyTests: XCTestCase {
         XCTAssertFalse(request.contains("rvt-token=pk_test"))
     }
 
+    func testActorWebSocketReconstructsUpgradeAndStripsHopByHopHeaders() throws {
+        let handshake = try XCTUnwrap(AmpWebSocketHandshake.request(
+            method: "GET",
+            path: "/actors/gateway/threadActor/websocket/",
+            version: "HTTP/1.1",
+            headers: [
+                ("Connection", "keep-alive, Upgrade, X-Hop"),
+                ("Upgrade", "websocket"),
+                ("X-Hop", "remove-me"),
+                ("Proxy-Authorization", "remove-me"),
+                ("Proxy-Connection", "keep-alive"),
+                ("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ=="),
+                ("Sec-WebSocket-Version", "13"),
+            ],
+            rivetToken: "pk_test"
+        ))
+        let request = try XCTUnwrap(String(data: handshake, encoding: .utf8))
+
+        XCTAssertEqual(request.components(separatedBy: "Connection: Upgrade\r\n").count - 1, 1)
+        XCTAssertEqual(request.components(separatedBy: "Upgrade: websocket\r\n").count - 1, 1)
+        XCTAssertFalse(request.localizedCaseInsensitiveContains("X-Hop:"))
+        XCTAssertFalse(request.localizedCaseInsensitiveContains("Proxy-Authorization:"))
+        XCTAssertFalse(request.localizedCaseInsensitiveContains("Proxy-Connection:"))
+        XCTAssertFalse(request.localizedCaseInsensitiveContains("keep-alive"))
+    }
+
 
     func testWebSocketUpgradeRoutesToAmpActors() throws {
         let headers = [
             ("Connection", "keep-alive, Upgrade"),
             ("Upgrade", "websocket"),
+            ("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ=="),
+            ("Sec-WebSocket-Version", "13"),
             ("Authorization", "Bearer amp-token"),
         ]
 
         XCTAssertEqual(
-            AmpRequestRouter.upstream(method: "GET", version: "HTTP/1.1", headers: headers),
+            AmpRequestRouter.upstream(method: "GET", path: "/actors/gateway/threadActor/websocket/", version: "HTTP/1.1", headers: headers),
             .actors
         )
 
         let firstFrame = Data([0x82, 0x02, 0xFF, 0x00])
         let handshake = try XCTUnwrap(AmpWebSocketHandshake.request(
             method: "GET",
-            path: "/v2/actors/thread?connection=abc",
+            path: "/actors/gateway/threadActor/websocket/?rvt-key=thread",
             version: "HTTP/1.1",
             headers: headers + [
                 ("Host", "localhost:8317"),
-                ("Sec-WebSocket-Key", "key=="),
                 ("Origin", "http://localhost:8317"),
             ],
             initialPayload: firstFrame
@@ -99,7 +126,7 @@ final class ThinkingProxyTests: XCTestCase {
         let headerLength = try XCTUnwrap(handshake.range(of: Data("\r\n\r\n".utf8))?.upperBound)
         let header = try XCTUnwrap(String(data: handshake[..<headerLength], encoding: .utf8))
         XCTAssertTrue(header.contains("Authorization: Bearer amp-token\r\n"))
-        XCTAssertTrue(header.contains("Sec-WebSocket-Key: key==\r\n"))
+        XCTAssertTrue(header.contains("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"))
         XCTAssertTrue(header.contains("Origin: http://localhost:8317\r\n"))
         XCTAssertTrue(header.contains("Host: ampcode.com\r\n"))
         XCTAssertFalse(header.contains("Host: localhost:8317"))
@@ -112,11 +139,27 @@ final class ThinkingProxyTests: XCTestCase {
             ("connection", "UPGRADE"),
             ("Upgrade", "h2c"),
             ("UPGRADE", "WebSocket"),
+            ("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ=="),
+            ("Sec-WebSocket-Version", "13"),
         ]
 
         XCTAssertEqual(
-            AmpRequestRouter.upstream(method: "get", version: "HTTP/1.1", headers: headers),
+            AmpRequestRouter.upstream(method: "get", path: "/actors/gateway/threadActor/websocket/", version: "HTTP/1.1", headers: headers),
             .actors
+        )
+    }
+
+    func testWebSocketUpgradeOutsideActorGatewayRemainsManagementTraffic() {
+        let headers = [
+            ("Connection", "Upgrade"),
+            ("Upgrade", "websocket"),
+            ("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ=="),
+            ("Sec-WebSocket-Version", "13"),
+        ]
+
+        XCTAssertEqual(
+            AmpRequestRouter.upstream(method: "GET", path: "/api/internal?getUserInfo", version: "HTTP/1.1", headers: headers),
+            .management
         )
     }
 
@@ -128,11 +171,15 @@ final class ThinkingProxyTests: XCTestCase {
             ("GET", "garbage", [("Connection", "Upgrade"), ("Upgrade", "websocket")]),
             ("GET", "HTTP/1.1", [("Connection", "keep-alive"), ("Upgrade", "websocket")]),
             ("GET", "HTTP/1.1", [("Connection", "Upgrade"), ("Upgrade", "h2c")]),
+            ("GET", "HTTP/1.1", [("Connection", "Upgrade"), ("Upgrade", "websocket"), ("Sec-WebSocket-Version", "13")]),
+            ("GET", "HTTP/1.1", [("Connection", "Upgrade"), ("Upgrade", "websocket"), ("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")]),
+            ("GET", "HTTP/1.1", [("Connection", "Upgrade"), ("Upgrade", "websocket"), ("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ=="), ("Sec-WebSocket-Version", "12")]),
+            ("GET", "HTTP/1.1", [("Connection", "Upgrade"), ("Upgrade", "websocket"), ("Sec-WebSocket-Key", "not-base64"), ("Sec-WebSocket-Version", "13")]),
         ]
 
         for (method, version, headers) in cases {
             XCTAssertEqual(
-                AmpRequestRouter.upstream(method: method, version: version, headers: headers),
+                AmpRequestRouter.upstream(method: method, path: "/actors/gateway/threadActor/websocket/", version: version, headers: headers),
                 .management
             )
         }


### PR DESCRIPTION
Closes #363.

## Problem

Amp changed in two incompatible ways:

1. Amp Neo opens a Rivet thread-actor WebSocket. ThinkingProxy treated that upgrade as ordinary HTTP, which caused `Unexpected error inside Amp CLI` / `connect_failed`.
2. Neo performs inference in Amp's cloud actor, so a localhost VibeProxy cannot redirect those model calls to local subscription OAuth. The bundled CLIProxyAPIPlus also removed its former Amp-specific `/api/provider/*` routes.

The first problem is fixable for current Amp transport. Credit-free local inference requires Amp classic mode.

## Approach

### Amp Neo transport

- Detect valid HTTP/1.1 WebSocket upgrades only on `/actors/gateway/*`.
- Validate RFC 6455 version 13 and the 16-byte WebSocket nonce.
- Rebuild the upstream actor handshake, add Amp's public Rivet routing token when needed, canonicalize duplicates, and strip hop-by-hop headers.
- Preserve already-received bytes and bridge the upgraded connection as an opaque bidirectional stream.

This lets current Amp reach its cloud actor, but it does not bypass Amp credits.

### Credit-free classic mode

- Map classic Amp provider requests onto CLIProxyAPIPlus's surviving generic endpoints:
  - Anthropic `/api/provider/anthropic/v1/*` -> `/v1/*`
  - OpenAI `/api/provider/openai/v1/*` -> `/v1/*`
  - Google `/api/provider/google/v1beta/*` and legacy v1beta1 publisher paths -> `/v1beta/*`
- Acknowledge classic-format `uploadThread` requests locally because Amp's current cloud API rejects that old schema.
- Document and pin the last verified classic CLI command:
  `npx -y @ampcode/cli@0.0.1779896748-g596c49 --take-me-back ...`

Classic threads are not synchronized to ampcode.com.

## Verification

- `swift test --package-path src` — 26 tests passed
- `swift build --package-path src -c release` — passed
- `make install` — signed app built, signature verified, and installed
- `git diff --check` — passed
- `gitleaks dir src/Sources/ThinkingProxy.swift --no-banner` — no leaks found
- Regression tests were observed failing before each route/acknowledgment implementation and passing afterward
- Installed-app listeners verified on ports 8317 and 8318
- Live classic inference traversed `/api/provider/anthropic/v1/messages -> /v1/messages`, returned `VIBEPROXY_CLASSIC_OK`, and exited 0 without Amp credits
- Installed `~/.local/bin/amp-classic` wrapper returned `AMP_CLASSIC_WRAPPER_OK` and exited 0
- Runtime logs confirmed classic thread uploads were acknowledged locally rather than forwarded to Amp

## Scope and limitations

- Current default `amp` is Amp Neo. Its inference remains cloud-hosted and requires Amp entitlement/credits.
- Use the pinned `amp-classic` command for local VibeProxy inference.
- Provider credential storage is unchanged.
- The existing `AppDelegate.windowDidClose` compiler warning is pre-existing and unrelated.
